### PR TITLE
Added more advanced navigation gutter system.

### DIFF
--- a/src/nl/rubensten/texifyidea/TexifyIcons.java
+++ b/src/nl/rubensten/texifyidea/TexifyIcons.java
@@ -84,4 +84,42 @@ public class TexifyIcons {
     public static final Icon LATEX_MODULE = IconLoader.getIcon(
             "/nl/rubensten/texifyidea/icons/latex-module.png"
     );
+
+    /**
+     * Get the file icon object that corresponds to the given file extension.
+     * <p>
+     * This method ignores case.
+     *
+     * @param extension
+     *         The extension of the file to get the icon of without a dot.
+     * @return The Icon that corresponds to the given extension.
+     * @throws IllegalArgumentException
+     *         When {@code extension} is null.
+     */
+    public static Icon getIconFromExtension(String extension) {
+        if (extension == null) {
+            return FILE;
+        }
+
+        switch (extension.toLowerCase()) {
+            case "tex":
+                return LATEX_FILE;
+            case "bib":
+                return BIBLIOGRAPHY_FILE;
+            case "cls":
+                return CLASS_FILE;
+            case "dtx":
+                return DOCUMENTED_LATEX_SOURCE;
+            case "sty":
+                return STYLE_FILE;
+            case "txt":
+                return TEXT_FILE;
+            case "log":
+                return TEXT_FILE;
+            case "pdf":
+                return PDF_FILE;
+            default:
+                return FILE;
+        }
+    }
 }

--- a/src/nl/rubensten/texifyidea/file/FileExtensionMatcher.java
+++ b/src/nl/rubensten/texifyidea/file/FileExtensionMatcher.java
@@ -1,0 +1,19 @@
+package nl.rubensten.texifyidea.file;
+
+/**
+ * @author Ruben Schellekens
+ */
+@FunctionalInterface
+public interface FileExtensionMatcher {
+
+    /**
+     * Checks if the given extension is supported ('matched')  or not..
+     *
+     * @param extension
+     *         The extension of the file to match.
+     * @return {@code true} if the extension matches, {@code false} when the extension does not
+     * match.
+     */
+    boolean matchesExtension(String extension);
+
+}

--- a/src/nl/rubensten/texifyidea/file/FileNameMatcher.java
+++ b/src/nl/rubensten/texifyidea/file/FileNameMatcher.java
@@ -1,0 +1,18 @@
+package nl.rubensten.texifyidea.file;
+
+/**
+ * @author Ruben Schellekens
+ */
+@FunctionalInterface
+public interface FileNameMatcher {
+
+    /**
+     * Checks if the given file name matches or not.
+     *
+     * @param fileName
+     *         The name of the file to match.
+     * @return {@code true} if the fileName matches, {@code false} when the fileName does not match.
+     */
+    boolean matchesName(String fileName);
+
+}

--- a/src/nl/rubensten/texifyidea/gutter/LatexNavigationGutter.java
+++ b/src/nl/rubensten/texifyidea/gutter/LatexNavigationGutter.java
@@ -7,6 +7,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiManager;
 import nl.rubensten.texifyidea.TexifyIcons;
+import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
+import nl.rubensten.texifyidea.lang.RequiredFileArgument;
 import nl.rubensten.texifyidea.psi.LatexCommands;
 import nl.rubensten.texifyidea.psi.LatexRequiredParam;
 import nl.rubensten.texifyidea.util.TexifyUtil;
@@ -14,6 +16,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Ruben Schellekens
@@ -23,36 +27,94 @@ public class LatexNavigationGutter extends RelatedItemLineMarkerProvider {
     @Override
     protected void collectNavigationMarkers(@NotNull PsiElement element,
                                             Collection<? super RelatedItemLineMarkerInfo> result) {
-        if (element instanceof LatexCommands) {
-            LatexCommands command = (LatexCommands)element;
-            if (command.getCommandToken().getText().equals("\\input")) {
+        // Only make markers when dealing with commands.
+        if (!(element instanceof LatexCommands)) {
+            return;
+        }
 
-                // Try to get the filename parameter
-                List<LatexRequiredParam> params = TexifyUtil.getRequiredParameters(command);
-                if (params.size() > 0) {
-                    String fileName = params.get(0).getGroup().getText();
-                    fileName = fileName.substring(1, fileName.length() - 1);
+        LatexCommands commands = (LatexCommands)element;
+        PsiElement commandToken = commands.getCommandToken();
+        if (commandToken == null) {
+            return;
+        }
 
-                    VirtualFile file = element.getContainingFile().getContainingDirectory().getVirtualFile().findFileByRelativePath(fileName);
+        String fullCommand = commands.getCommandToken().getText();
+        if (fullCommand == null) {
+            return;
+        }
 
-                    // Optional file extension
-                    if (file == null) {
-                        file = element.getContainingFile().getContainingDirectory().getVirtualFile().findFileByRelativePath(fileName + ".tex");
-                    }
+        // Fetch the corresponding LatexNoMathCommand object.
+        String commandName = fullCommand.substring(1);
+        Optional<LatexNoMathCommand> commandHuh = LatexNoMathCommand.get(commandName);
+        if (!commandHuh.isPresent()) {
+            return;
+        }
 
-                    // Build gutter icon if file was found
-                    if (file != null) {
-                        NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
-                                .create(TexifyIcons.LATEX_FILE)
-                                .setTarget(PsiManager.getInstance(element.getProject()).findFile(file))
-                                .setTooltipText("Go to input file");
+        LatexNoMathCommand command = commandHuh.get();
+        List<RequiredFileArgument> arguments = command.getArgumentsOf(RequiredFileArgument.class);
 
-                        result.add(builder.createLineMarkerInfo(element));
-                    }
-                }
+        if (arguments.isEmpty()) {
+            return;
+        }
 
+        // Get the required file arguments.
+        RequiredFileArgument argument = arguments.get(0);
+        List<LatexRequiredParam> requiredParams = TexifyUtil.getRequiredParameters(commands);
+        if (requiredParams.isEmpty()) {
+            return;
+        }
+
+        // Make filename. Substring is to remove { and }.
+        String fileName = requiredParams.get(0).getGroup().getText();
+        fileName = fileName.substring(1, fileName.length() - 1);
+
+        // Look up target file.
+        VirtualFile directory = element.getContainingFile().getContainingDirectory().getVirtualFile();
+        Optional<VirtualFile> fileHuh = findFile(directory, fileName, argument.getSupportedExtensions());
+        if (!fileHuh.isPresent()) {
+            return;
+        }
+
+        // Build gutter icon.
+        VirtualFile file = fileHuh.get();
+        NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
+                .create(TexifyIcons.getIconFromExtension(file.getExtension()))
+                .setTarget(PsiManager.getInstance(element.getProject()).findFile(file))
+                .setTooltipText("Go to referenced file '" + file.getName() + "'");
+
+        result.add(builder.createLineMarkerInfo(element));
+    }
+
+    /**
+     * Looks for a certain file.
+     * <p>
+     * First looks if the file including extensions exists, when it doesn't it tries to append
+     * all possible extensions until it finds a good one.
+     *
+     * @param directory
+     *         The directory where the search is rooted from.
+     * @param fileName
+     *         The name of the file relative to the directory.
+     * @param extensions
+     *         Set of all supported extensions to look for.
+     * @return The matching file.
+     */
+    private Optional<VirtualFile> findFile(VirtualFile directory, String fileName,
+                                           Set<String> extensions) {
+        VirtualFile file = directory.findFileByRelativePath(fileName);
+        if (file != null) {
+            return Optional.of(file);
+        }
+
+        for (String extension : extensions) {
+            file = directory.findFileByRelativePath(fileName + "." + extension);
+
+            if (file != null) {
+                return Optional.of(file);
             }
         }
+
+        return Optional.empty();
     }
 
 }

--- a/src/nl/rubensten/texifyidea/insight/LatexParameterInfoHandler.java
+++ b/src/nl/rubensten/texifyidea/insight/LatexParameterInfoHandler.java
@@ -1,11 +1,7 @@
 package nl.rubensten.texifyidea.insight;
 
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.lang.parameterInfo.CreateParameterInfoContext;
-import com.intellij.lang.parameterInfo.ParameterInfoContext;
-import com.intellij.lang.parameterInfo.ParameterInfoHandler;
-import com.intellij.lang.parameterInfo.ParameterInfoUIContext;
-import com.intellij.lang.parameterInfo.UpdateParameterInfoContext;
+import com.intellij.lang.parameterInfo.*;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -15,6 +11,8 @@ import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
 import nl.rubensten.texifyidea.psi.LatexCommands;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
 
 /**
  * @author Sten Wessel
@@ -52,19 +50,20 @@ public class LatexParameterInfoHandler implements ParameterInfoHandler<LatexComm
 
     @Override
     public void showParameterInfo(@NotNull LatexCommands element, @NotNull CreateParameterInfoContext context) {
-
-        LatexNoMathCommand cmd = LatexNoMathCommand.get(element.getCommandToken().getText().substring(1));
-        if (cmd != null) {
-            context.setItemsToShow(new Object[] {cmd});
-            context.showHint(element, element.getTextOffset(), this);
+        Optional<LatexNoMathCommand> commandHuh =
+                LatexNoMathCommand.get(element.getCommandToken().getText().substring(1));
+        if (!commandHuh.isPresent()) {
+            return;
         }
 
+        context.setItemsToShow(new Object[] { commandHuh.get() });
+        context.showHint(element, element.getTextOffset(), this);
     }
 
     @Nullable
     @Override
     public LatexCommands findElementForUpdatingParameterInfo(@NotNull UpdateParameterInfoContext
-                                                                         context) {
+                                                                     context) {
         return findLatexCommand(context.getFile(), context.getOffset());
     }
 

--- a/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.java
+++ b/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.java
@@ -1,12 +1,12 @@
 package nl.rubensten.texifyidea.lang;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author Sten Wessel
  */
 public enum LatexNoMathCommand {
+
     A_RING("aa", "å"),
     CAPITAL_A_RING("AA", "Å"),
     AE("ae", "æ"),
@@ -19,7 +19,7 @@ public enum LatexNoMathCommand {
     BFSERIES("bfseries"),
     BIBITEM("bibitem", new OptionalArgument("label"), new RequiredArgument("citekey")),
     BIBLIOGRAPHYSTYLE("bibliographystyle", new RequiredArgument("style")),
-    BIBLIOGRAPHY("bibliography", new RequiredArgument("bibfile")),
+    BIBLIOGRAPHY("bibliography", new RequiredFileArgument("bibliography file", "bib")),
     BIGSKIP("bigskip"),
     BOLDMATH("boldmath"),
     CAPTION("caption", new OptionalArgument("shorttext"),
@@ -32,11 +32,11 @@ public enum LatexNoMathCommand {
     CLEARPAGE("clearpage"),
     COLUMNWIDTH("columnwidth"),
     CONTENTSLINE("contentsline", new RequiredArgument("type"),
-                 new RequiredArgument("text"), new RequiredArgument("page")),
+            new RequiredArgument("text"), new RequiredArgument("page")),
     CONTENTSNAME("contentsname", new RequiredArgument("name")),
     DATE("date", new RequiredArgument("text")),
     DOCUMENTCLASS("documentclass", new OptionalArgument("options"),
-                  new RequiredArgument("class")),
+            new RequiredArgument("class")),
     EM("em"),
     EMPH("emph", new RequiredArgument("text")),
     ENLARGETHISPAGE("enlargethispage", new RequiredArgument("size")),
@@ -56,15 +56,15 @@ public enum LatexNoMathCommand {
     FONTSIZE("fontsize", new RequiredArgument("size"), new RequiredArgument("skip")),
     FOOTNOTESIZE("footnotesize"),
     FOOTNOTETEXT("footnotetext", new OptionalArgument("number"),
-                 new RequiredArgument("text")),
+            new RequiredArgument("text")),
     FOOTNOTE("footnote", new OptionalArgument("number"), new RequiredArgument("text")),
     FRAMEBOX("framebox", new OptionalArgument("width"),
-             new OptionalArgument("pos"), new OptionalArgument("text")),
+            new OptionalArgument("pos"), new OptionalArgument("text")),
     FRAME("frame", new RequiredArgument("text")),
     FRQ("frq", "›"),
     FRQQ("frqq", "»"),
     GLOSSARYENTRY("glossaryentry", new RequiredArgument("text"),
-                  new RequiredArgument("pagenum")),
+            new RequiredArgument("pagenum")),
     GLOSSARY("glossary", new RequiredArgument("text")),
     GLQ("glq", ","),
     GLQQ("glqq", "„"),
@@ -80,9 +80,9 @@ public enum LatexNoMathCommand {
     CAPITAL_HUGE("Huge"),
     HYPHENATION("hyphenation", new RequiredArgument("words")),
     I("i", "i (dotless)"),
-    INCLUDE("include", new RequiredArgument("file")),
-    INPUT("input", new RequiredArgument("file")),
-    INCLUDEONLY("includeonly", new RequiredArgument("files")),
+    INCLUDE("include", new RequiredFileArgument("source file", "tex")),
+    INPUT("input", new RequiredFileArgument("source file", "tex")),
+    INCLUDEONLY("includeonly", new RequiredFileArgument("source file", "tex")),
     INDEXNAME("indexname", new RequiredArgument("name")),
     INDEXSPACE("indexspace"),
     INDEX("intex", new RequiredArgument("entry")),
@@ -113,16 +113,16 @@ public enum LatexNoMathCommand {
     MBOX("mbox", new RequiredArgument("text")),
     MEDSKIP("medskip"),
     MULTICOLUMN("multicolumn", new RequiredArgument("cols"),
-                new RequiredArgument("pos"), new RequiredArgument("text")),
+            new RequiredArgument("pos"), new RequiredArgument("text")),
     NEWLABEL("newlabel"),
     NEWLENGTH("newlength", new RequiredArgument("length")),
     NEWLINE("newline"),
     NEWPAGE("newpage"),
     NEWTHEOREM("newtheorem", new RequiredArgument("envname"),
-               new OptionalArgument("numberedlike"), new RequiredArgument("caption"),
-               new OptionalArgument("within")),
+            new OptionalArgument("numberedlike"), new RequiredArgument("caption"),
+            new OptionalArgument("within")),
     NEWTHEOREM_STAR("newtheorem*", new RequiredArgument("envname"),
-                    new RequiredArgument("caption")),
+            new RequiredArgument("caption")),
     NOCITE("nocite", new RequiredArgument("keys")),
     NOFILES("nofiles"),
     NOLINEBREAK("nolinebreak", new OptionalArgument("number")),
@@ -141,11 +141,11 @@ public enum LatexNoMathCommand {
     PAGESTYLE("pagestyle", new RequiredArgument("style")),
     PAGETOTAL("pagetotal"),
     PARAGRAPH("paragraph", new OptionalArgument("shorttitle"),
-              new RequiredArgument("title")),
+            new RequiredArgument("title")),
     PARAGRAPH_STAR("paragraph*", new RequiredArgument("title")),
     PARAGRAPHMARK("paragraphmark"),
     PARBOX("parbox", new OptionalArgument("pos"), new RequiredArgument("width"),
-           new RequiredArgument("text")),
+            new RequiredArgument("text")),
     PART("part", new OptionalArgument("shorttitle"), new RequiredArgument("title")),
     PART_STAR("part*", new RequiredArgument("title")),
     PARTNAME("partname", new RequiredArgument("name")),
@@ -162,10 +162,10 @@ public enum LatexNoMathCommand {
     ROMAN("roman", new RequiredArgument("counter")),
     CAPITAL_ROBAN("Roman", new RequiredArgument("counter")),
     RULE("rule", new OptionalArgument("line"), new RequiredArgument("width"),
-         new RequiredArgument("thickness")),
+            new RequiredArgument("thickness")),
     SAMEPAGE("samepage"),
     SBOX("sbox", new RequiredArgument("cmd"),
-         new RequiredArgument("length")),
+            new RequiredArgument("length")),
     SCRIPTSIZE("scriptsize"),
     SCSHAPE("scshape"),
     SECTION("section", new OptionalArgument("shorttitle"),
@@ -173,10 +173,10 @@ public enum LatexNoMathCommand {
     SECTION_STAR("section", new RequiredArgument("title")),
     SELECTFONT("selectfont"),
     SETLENGTH("setlength", new RequiredArgument("cmd"),
-              new RequiredArgument("length")),
+            new RequiredArgument("length")),
     SFFAMILY("sffamily"),
     SHORTSTACK("shortstack", new OptionalArgument("pos"),
-               new RequiredArgument("text")),
+            new RequiredArgument("text")),
     SLSHAPE("slshape"),
     SMALL("small"),
     SMASH("smash"),
@@ -185,16 +185,16 @@ public enum LatexNoMathCommand {
     STOP("stop"),
     SUBITEM("subitem"),
     SUBPARAGRAPH("subparagraph", new OptionalArgument("shorttitle"),
-                 new RequiredArgument("title")),
+            new RequiredArgument("title")),
     SUBPARAGRAPH_STAR("subparagraph*", new RequiredArgument("title")),
     SUBPARAGRAPHMARK("subparagraphmark", new RequiredArgument("code")),
     SUBSECTION("subsection", new OptionalArgument("shorttitle"),
-               new RequiredArgument("title")),
+            new RequiredArgument("title")),
     SUBSECTION_STAR("subsection*", new RequiredArgument("title")),
     SUBSECTIONMARK("subsectionmark", new RequiredArgument("code")),
     SUBSUBITEM("subsubitem"),
     SUBSUBSECTION("subsubsection", new OptionalArgument("shorttitle"),
-                  new RequiredArgument("title")),
+            new RequiredArgument("title")),
     SUBSUBSECTION_STAR("subsubsection*", new RequiredArgument("title")),
     SUBSUBSECTIONMARK("subsubsectionmark", new RequiredArgument("code")),
     SUPPRESSFLOATS("suppressfloats", new OptionalArgument("placement")),
@@ -261,7 +261,7 @@ public enum LatexNoMathCommand {
     UNDERLINE("underline", new RequiredArgument("text")),
     UPSHAPE("upshape"),
     USEPACKAGE("usepackage", new OptionalArgument("options"),
-               new RequiredArgument("package")),
+            new RequiredArgument("package")),
     VDOTS("vdots", "⋮"),
     VLINE("vline"),
     VSPACE("vspace", new RequiredArgument("length")),
@@ -272,29 +272,28 @@ public enum LatexNoMathCommand {
         New definitions
      */
     NEWCOMMAND("newcommand", new RequiredArgument("cmd"), new OptionalArgument("args"),
-               new OptionalArgument("default"), new RequiredArgument("def")),
+            new OptionalArgument("default"), new RequiredArgument("def")),
     NEWCOMMAND_STAR("newcommand*", new RequiredArgument("cmd"),
-                    new OptionalArgument("args"), new OptionalArgument("default"),
-                    new RequiredArgument("def")),
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("def")),
     PROVIDECOMMAND("providecommand", new RequiredArgument("cmd"),
-                   new OptionalArgument("args"), new OptionalArgument("default"),
-                   new RequiredArgument("def")),
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("def")),
     PROVIDECOMMAND_STAR("providecommand*", new RequiredArgument("cmd"),
-                        new OptionalArgument("args"), new OptionalArgument("default"),
-                        new RequiredArgument("def")),
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("def")),
     RENEWCOMMAND("renewcommand", new RequiredArgument("cmd"),
-                 new OptionalArgument("args"), new OptionalArgument("default"),
-                 new RequiredArgument("def")),
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("def")),
     RENEWCOMMAND_STAR("renewcommand*", new RequiredArgument("cmd"),
-                      new OptionalArgument("args"), new OptionalArgument("default"),
-                      new RequiredArgument("def")),
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("def")),
     NEWENVIRONMENT("newenvironment", new RequiredArgument("name"),
-                   new OptionalArgument("args"), new OptionalArgument("default"),
-                   new RequiredArgument("begdef"), new RequiredArgument("enddef")),
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("begdef"), new RequiredArgument("enddef")),
     RENEWENVIRONMENT("renewenvironment", new RequiredArgument("name"),
-                     new OptionalArgument("args"), new OptionalArgument("default"),
-                     new RequiredArgument("begdef"), new RequiredArgument("enddef")),
-    ;
+            new OptionalArgument("args"), new OptionalArgument("default"),
+            new RequiredArgument("begdef"), new RequiredArgument("enddef")),;
 
     private static final Map<String, LatexNoMathCommand> lookup = new HashMap<>();
 
@@ -318,8 +317,8 @@ public enum LatexNoMathCommand {
         this.arguments = arguments;
     }
 
-    public static LatexNoMathCommand get(String command) {
-        return lookup.get(command);
+    public static Optional<LatexNoMathCommand> get(String command) {
+        return Optional.ofNullable(lookup.get(command));
     }
 
     public String getCommand() {
@@ -332,6 +331,18 @@ public enum LatexNoMathCommand {
 
     public Argument[] getArguments() {
         return arguments;
+    }
+
+    public <T extends Argument> List<T> getArgumentsOf(Class<T> clazz) {
+        List<T> requiredArguments = new ArrayList<>();
+
+        for (Argument argument : arguments) {
+            if (clazz.isAssignableFrom(argument.getClass())) {
+                requiredArguments.add((T)argument);
+            }
+        }
+
+        return requiredArguments;
     }
 
     public String getArgumentsDisplay() {

--- a/src/nl/rubensten/texifyidea/lang/RequiredArgument.java
+++ b/src/nl/rubensten/texifyidea/lang/RequiredArgument.java
@@ -4,6 +4,7 @@ package nl.rubensten.texifyidea.lang;
  * @author Sten Wessel
  */
 public class RequiredArgument extends Argument {
+
     RequiredArgument(String name) {
         super(name);
     }

--- a/src/nl/rubensten/texifyidea/lang/RequiredFileArgument.java
+++ b/src/nl/rubensten/texifyidea/lang/RequiredFileArgument.java
@@ -1,0 +1,87 @@
+package nl.rubensten.texifyidea.lang;
+
+import nl.rubensten.texifyidea.file.FileExtensionMatcher;
+import nl.rubensten.texifyidea.file.FileNameMatcher;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Ignores case: everything will be converted to lower case.
+ *
+ * @author Ruben Schellekens
+ */
+public class RequiredFileArgument extends RequiredArgument implements FileNameMatcher, FileExtensionMatcher {
+
+    private Set<String> extensions;
+    private Pattern pattern;
+
+    /**
+     * Create a new required file argument with a given name and a pattern that matches
+     * corresponding file names.
+     *
+     * @param name
+     *         The name of the required argument.
+     * @param extensions
+     *         All supported extensions.
+     */
+    protected RequiredFileArgument(String name, String... extensions) {
+        super(name);
+        setExtensions(extensions);
+    }
+
+    /**
+     * Registers all extensions and compiles them to a regex file matcher.
+     *
+     * @param extensions
+     *         All the file extensions (lower case) that should result in match for this required
+     *         argument. The file extensions should <em>not</em> have a dot. When given no
+     *         extensions, all files will match.
+     */
+    private void setExtensions(String... extensions) {
+        this.extensions = new HashSet<>();
+
+        StringBuilder regex = new StringBuilder(".*");
+
+        if (extensions.length == 0) {
+            setRegex(regex.toString());
+            return;
+        }
+
+        regex.append("(");
+        for (String extension : extensions) {
+            regex.append("\\.");
+
+            String extensionLower = extension.toLowerCase();
+            regex.append(extensionLower);
+            this.extensions.add(extensionLower);
+
+            if (extension != extensions[extensions.length - 1]) {
+                regex.append("|");
+            }
+        }
+        regex.append(")$");
+
+        setRegex(regex.toString());
+    }
+
+    private void setRegex(String regex) {
+        this.pattern = Pattern.compile(regex);
+    }
+
+    public Set<String> getSupportedExtensions() {
+        return Collections.unmodifiableSet(extensions);
+    }
+
+    @Override
+    public boolean matchesName(String fileName) {
+        return pattern.matcher(fileName.toLowerCase()).matches();
+    }
+
+    @Override
+    public boolean matchesExtension(String extension) {
+        return extensions.contains(extension);
+    }
+}


### PR DESCRIPTION
## Changes
### Added a more advanced system for navigation gutter icons.
![image](https://cloud.githubusercontent.com/assets/17410729/23022128/891f4bbc-f44f-11e6-878f-1ae9caec5b2f.png)

`\include`, `\includeonly`, and `\bibliography` now also get navigation icons. The new system allows an easier method to add support for more commands.

### Other changes
- Refactored `LatexNavigationGutter`
- Added `TexifyIcons#getIconFromExtension(String)`