### PR TITLE
Recognize indent within LaTeX environment

### DIFF
--- a/gen/nl/rubensten/texifyidea/grammar/LatexLexer.java
+++ b/gen/nl/rubensten/texifyidea/grammar/LatexLexer.java
@@ -53,8 +53,9 @@ public class LatexLexer implements FlexLexer {
 
   /* The ZZ_CMAP_A table has 320 entries */
   static final char ZZ_CMAP_A[] = zzUnpackCMap(
-    "\11\0\1\2\1\1\2\7\1\1\22\0\1\2\3\0\1\14\1\13\4\0\1\15\26\0\32\11\1\3\1\10"+
-    "\1\4\3\0\32\11\1\5\1\0\1\6\7\0\1\12\242\0\2\12\26\0");
+    "\11\0\1\2\1\1\2\7\1\1\22\0\1\2\3\0\1\22\1\21\4\0\1\23\26\0\32\17\1\3\1\10"+
+    "\1\4\3\0\1\17\1\11\1\17\1\16\1\12\1\17\1\13\1\17\1\14\4\17\1\15\14\17\1\5"+
+    "\1\0\1\6\7\0\1\20\242\0\2\20\26\0");
 
   /** 
    * Translates DFA states to action switch labels.
@@ -63,10 +64,11 @@ public class LatexLexer implements FlexLexer {
 
   private static final String ZZ_ACTION_PACKED_0 =
     "\2\0\1\1\1\2\1\3\1\4\1\5\1\6\1\7"+
-    "\1\10\1\11\1\12\1\13\1\14\1\15\1\16\1\14";
+    "\1\10\1\11\1\12\1\13\1\14\1\15\1\16\6\14"+
+    "\1\17\1\14\1\20";
 
   private static int [] zzUnpackAction() {
-    int [] result = new int[17];
+    int [] result = new int[25];
     int offset = 0;
     offset = zzUnpackAction(ZZ_ACTION_PACKED_0, offset, result);
     return result;
@@ -91,12 +93,13 @@ public class LatexLexer implements FlexLexer {
   private static final int [] ZZ_ROWMAP = zzUnpackRowMap();
 
   private static final String ZZ_ROWMAP_PACKED_0 =
-    "\0\0\0\16\0\34\0\52\0\70\0\70\0\70\0\70"+
-    "\0\106\0\124\0\70\0\34\0\70\0\70\0\70\0\70"+
-    "\0\142";
+    "\0\0\0\24\0\50\0\74\0\120\0\120\0\120\0\120"+
+    "\0\144\0\170\0\120\0\50\0\120\0\120\0\120\0\120"+
+    "\0\214\0\240\0\264\0\310\0\334\0\360\0\264\0\u0104"+
+    "\0\264";
 
   private static int [] zzUnpackRowMap() {
-    int [] result = new int[17];
+    int [] result = new int[25];
     int offset = 0;
     offset = zzUnpackRowMap(ZZ_ROWMAP_PACKED_0, offset, result);
     return result;
@@ -120,15 +123,18 @@ public class LatexLexer implements FlexLexer {
 
   private static final String ZZ_TRANS_PACKED_0 =
     "\1\3\2\4\1\5\1\6\1\7\1\10\1\4\1\11"+
-    "\2\3\1\12\1\13\1\14\1\3\2\4\1\5\1\6"+
-    "\1\7\1\10\1\4\1\11\2\3\1\12\1\15\1\14"+
-    "\3\3\4\0\1\3\1\0\2\3\2\0\2\3\2\4"+
-    "\4\0\1\4\1\0\2\3\2\0\1\3\16\0\3\16"+
-    "\1\17\1\20\2\16\1\0\1\16\1\21\1\0\3\16"+
-    "\1\12\1\0\14\12\11\0\1\21\4\0";
+    "\10\3\1\12\1\13\1\14\1\3\2\4\1\5\1\6"+
+    "\1\7\1\10\1\4\1\11\10\3\1\12\1\15\1\14"+
+    "\3\3\4\0\1\3\1\0\10\3\2\0\2\3\2\4"+
+    "\4\0\1\4\1\0\10\3\2\0\1\3\24\0\3\16"+
+    "\1\17\1\20\2\16\1\0\1\16\1\21\1\22\5\23"+
+    "\1\0\3\16\1\12\1\0\22\12\11\0\1\23\1\24"+
+    "\5\23\15\0\4\23\1\25\2\23\15\0\7\23\15\0"+
+    "\2\23\1\26\4\23\15\0\5\23\1\27\1\23\15\0"+
+    "\3\23\1\30\3\23\15\0\4\23\1\31\2\23\4\0";
 
   private static int [] zzUnpackTrans() {
-    int [] result = new int[112];
+    int [] result = new int[280];
     int offset = 0;
     offset = zzUnpackTrans(ZZ_TRANS_PACKED_0, offset, result);
     return result;
@@ -166,10 +172,10 @@ public class LatexLexer implements FlexLexer {
   private static final int [] ZZ_ATTRIBUTE = zzUnpackAttribute();
 
   private static final String ZZ_ATTRIBUTE_PACKED_0 =
-    "\2\0\2\1\4\11\2\1\1\11\1\1\4\11\1\1";
+    "\2\0\2\1\4\11\2\1\1\11\1\1\4\11\11\1";
 
   private static int [] zzUnpackAttribute() {
-    int [] result = new int[17];
+    int [] result = new int[25];
     int offset = 0;
     offset = zzUnpackAttribute(ZZ_ATTRIBUTE_PACKED_0, offset, result);
     return result;
@@ -479,59 +485,67 @@ public class LatexLexer implements FlexLexer {
           case 1: 
             { return NORMAL_TEXT;
             }
-          case 15: break;
+          case 17: break;
           case 2: 
             { return com.intellij.psi.TokenType.WHITE_SPACE;
             }
-          case 16: break;
+          case 18: break;
           case 3: 
             { return OPEN_BRACKET;
             }
-          case 17: break;
+          case 19: break;
           case 4: 
             { return CLOSE_BRACKET;
             }
-          case 18: break;
+          case 20: break;
           case 5: 
             { return OPEN_BRACE;
             }
-          case 19: break;
+          case 21: break;
           case 6: 
             { return CLOSE_BRACE;
             }
-          case 20: break;
+          case 22: break;
           case 7: 
             { return com.intellij.psi.TokenType.BAD_CHARACTER;
             }
-          case 21: break;
+          case 23: break;
           case 8: 
             { return COMMENT_TOKEN;
             }
-          case 22: break;
+          case 24: break;
           case 9: 
             { yybegin(INLINE_MATH); return INLINE_MATH_START;
             }
-          case 23: break;
+          case 25: break;
           case 10: 
             { return STAR;
             }
-          case 24: break;
+          case 26: break;
           case 11: 
             { yybegin(YYINITIAL); return INLINE_MATH_END;
             }
-          case 25: break;
+          case 27: break;
           case 12: 
             { return COMMAND_TOKEN;
             }
-          case 26: break;
+          case 28: break;
           case 13: 
             { return DISPLAY_MATH_START;
             }
-          case 27: break;
+          case 29: break;
           case 14: 
             { return DISPLAY_MATH_END;
             }
-          case 28: break;
+          case 30: break;
+          case 15: 
+            { return END_TOKEN;
+            }
+          case 31: break;
+          case 16: 
+            { return BEGIN_TOKEN;
+            }
+          case 32: break;
           default:
             zzScanError(ZZ_NO_MATCH);
           }

--- a/gen/nl/rubensten/texifyidea/psi/LatexBeginCommand.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexBeginCommand.java
@@ -1,0 +1,13 @@
+// This is a generated file. Not intended for manual editing.
+package nl.rubensten.texifyidea.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface LatexBeginCommand extends PsiElement {
+
+  @NotNull
+  List<LatexParameter> getParameterList();
+
+}

--- a/gen/nl/rubensten/texifyidea/psi/LatexEndCommand.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexEndCommand.java
@@ -1,0 +1,13 @@
+// This is a generated file. Not intended for manual editing.
+package nl.rubensten.texifyidea.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface LatexEndCommand extends PsiElement {
+
+  @NotNull
+  List<LatexParameter> getParameterList();
+
+}

--- a/gen/nl/rubensten/texifyidea/psi/LatexEnvironment.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexEnvironment.java
@@ -1,0 +1,19 @@
+// This is a generated file. Not intended for manual editing.
+package nl.rubensten.texifyidea.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface LatexEnvironment extends PsiElement {
+
+  @NotNull
+  LatexBeginCommand getBeginCommand();
+
+  @NotNull
+  List<LatexContent> getContentList();
+
+  @NotNull
+  LatexEndCommand getEndCommand();
+
+}

--- a/gen/nl/rubensten/texifyidea/psi/LatexNoMathContent.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexNoMathContent.java
@@ -14,6 +14,9 @@ public interface LatexNoMathContent extends PsiElement {
   LatexComment getComment();
 
   @Nullable
+  LatexEnvironment getEnvironment();
+
+  @Nullable
   LatexGroup getGroup();
 
   @Nullable

--- a/gen/nl/rubensten/texifyidea/psi/LatexTypes.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexTypes.java
@@ -8,10 +8,13 @@ import nl.rubensten.texifyidea.psi.impl.*;
 
 public interface LatexTypes {
 
+  IElementType BEGIN_COMMAND = new LatexElementType("BEGIN_COMMAND");
   IElementType COMMANDS = new LatexElementType("COMMANDS");
   IElementType COMMENT = new LatexElementType("COMMENT");
   IElementType CONTENT = new LatexElementType("CONTENT");
   IElementType DISPLAY_MATH = new LatexElementType("DISPLAY_MATH");
+  IElementType END_COMMAND = new LatexElementType("END_COMMAND");
+  IElementType ENVIRONMENT = new LatexElementType("ENVIRONMENT");
   IElementType GROUP = new LatexElementType("GROUP");
   IElementType INLINE_MATH = new LatexElementType("INLINE_MATH");
   IElementType MATH_ENVIRONMENT = new LatexElementType("MATH_ENVIRONMENT");
@@ -21,12 +24,14 @@ public interface LatexTypes {
   IElementType PARAMETER = new LatexElementType("PARAMETER");
   IElementType REQUIRED_PARAM = new LatexElementType("REQUIRED_PARAM");
 
+  IElementType BEGIN_TOKEN = new LatexTokenType("\\begin");
   IElementType CLOSE_BRACE = new LatexTokenType("CLOSE_BRACE");
   IElementType CLOSE_BRACKET = new LatexTokenType("CLOSE_BRACKET");
   IElementType COMMAND_TOKEN = new LatexTokenType("COMMAND_TOKEN");
   IElementType COMMENT_TOKEN = new LatexTokenType("COMMENT_TOKEN");
   IElementType DISPLAY_MATH_END = new LatexTokenType("\\]");
   IElementType DISPLAY_MATH_START = new LatexTokenType("\\[");
+  IElementType END_TOKEN = new LatexTokenType("\\end");
   IElementType INLINE_MATH_END = new LatexTokenType("$");
   IElementType INLINE_MATH_START = new LatexTokenType("INLINE_MATH_START");
   IElementType NORMAL_TEXT = new LatexTokenType("NORMAL_TEXT");
@@ -37,7 +42,10 @@ public interface LatexTypes {
   class Factory {
     public static PsiElement createElement(ASTNode node) {
       IElementType type = node.getElementType();
-       if (type == COMMANDS) {
+       if (type == BEGIN_COMMAND) {
+        return new LatexBeginCommandImpl(node);
+      }
+      else if (type == COMMANDS) {
         return new LatexCommandsImpl(node);
       }
       else if (type == COMMENT) {
@@ -48,6 +56,12 @@ public interface LatexTypes {
       }
       else if (type == DISPLAY_MATH) {
         return new LatexDisplayMathImpl(node);
+      }
+      else if (type == END_COMMAND) {
+        return new LatexEndCommandImpl(node);
+      }
+      else if (type == ENVIRONMENT) {
+        return new LatexEnvironmentImpl(node);
       }
       else if (type == GROUP) {
         return new LatexGroupImpl(node);

--- a/gen/nl/rubensten/texifyidea/psi/LatexVisitor.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexVisitor.java
@@ -7,6 +7,10 @@ import com.intellij.psi.PsiElement;
 
 public class LatexVisitor extends PsiElementVisitor {
 
+  public void visitBeginCommand(@NotNull LatexBeginCommand o) {
+    visitPsiElement(o);
+  }
+
   public void visitCommands(@NotNull LatexCommands o) {
     visitPsiElement(o);
   }
@@ -20,6 +24,14 @@ public class LatexVisitor extends PsiElementVisitor {
   }
 
   public void visitDisplayMath(@NotNull LatexDisplayMath o) {
+    visitPsiElement(o);
+  }
+
+  public void visitEndCommand(@NotNull LatexEndCommand o) {
+    visitPsiElement(o);
+  }
+
+  public void visitEnvironment(@NotNull LatexEnvironment o) {
     visitPsiElement(o);
   }
 

--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexBeginCommandImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexBeginCommandImpl.java
@@ -1,0 +1,35 @@
+// This is a generated file. Not intended for manual editing.
+package nl.rubensten.texifyidea.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.rubensten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.rubensten.texifyidea.psi.*;
+
+public class LatexBeginCommandImpl extends ASTWrapperPsiElement implements LatexBeginCommand {
+
+  public LatexBeginCommandImpl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull LatexVisitor visitor) {
+    visitor.visitBeginCommand(this);
+  }
+
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public List<LatexParameter> getParameterList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexParameter.class);
+  }
+
+}

--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexEndCommandImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexEndCommandImpl.java
@@ -1,0 +1,35 @@
+// This is a generated file. Not intended for manual editing.
+package nl.rubensten.texifyidea.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.rubensten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.rubensten.texifyidea.psi.*;
+
+public class LatexEndCommandImpl extends ASTWrapperPsiElement implements LatexEndCommand {
+
+  public LatexEndCommandImpl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull LatexVisitor visitor) {
+    visitor.visitEndCommand(this);
+  }
+
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public List<LatexParameter> getParameterList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexParameter.class);
+  }
+
+}

--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexEnvironmentImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexEnvironmentImpl.java
@@ -1,0 +1,47 @@
+// This is a generated file. Not intended for manual editing.
+package nl.rubensten.texifyidea.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static nl.rubensten.texifyidea.psi.LatexTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import nl.rubensten.texifyidea.psi.*;
+
+public class LatexEnvironmentImpl extends ASTWrapperPsiElement implements LatexEnvironment {
+
+  public LatexEnvironmentImpl(ASTNode node) {
+    super(node);
+  }
+
+  public void accept(@NotNull LatexVisitor visitor) {
+    visitor.visitEnvironment(this);
+  }
+
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof LatexVisitor) accept((LatexVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @NotNull
+  public LatexBeginCommand getBeginCommand() {
+    return findNotNullChildByClass(LatexBeginCommand.class);
+  }
+
+  @Override
+  @NotNull
+  public List<LatexContent> getContentList() {
+    return PsiTreeUtil.getChildrenOfTypeAsList(this, LatexContent.class);
+  }
+
+  @Override
+  @NotNull
+  public LatexEndCommand getEndCommand() {
+    return findNotNullChildByClass(LatexEndCommand.class);
+  }
+
+}

--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexNoMathContentImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexNoMathContentImpl.java
@@ -40,6 +40,12 @@ public class LatexNoMathContentImpl extends ASTWrapperPsiElement implements Late
 
   @Override
   @Nullable
+  public LatexEnvironment getEnvironment() {
+    return findChildByClass(LatexEnvironment.class);
+  }
+
+  @Override
+  @Nullable
   public LatexGroup getGroup() {
     return findChildByClass(LatexGroup.class);
   }

--- a/src/nl/rubensten/texifyidea/formatting/LatexBlock.java
+++ b/src/nl/rubensten/texifyidea/formatting/LatexBlock.java
@@ -12,7 +12,6 @@ import com.intellij.lang.ASTNode;
 import com.intellij.psi.TokenType;
 import com.intellij.psi.formatter.common.AbstractBlock;
 import com.intellij.psi.tree.TokenSet;
-import nl.rubensten.texifyidea.file.LatexFile;
 import nl.rubensten.texifyidea.psi.LatexTypes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,6 +27,10 @@ import static nl.rubensten.texifyidea.psi.LatexPsiUtil.hasElementType;
 public class LatexBlock extends AbstractBlock {
     private static final TokenSet LATEX_DISPLAY_MATH_DELIM = TokenSet.create(
             LatexTypes.DISPLAY_MATH_START, LatexTypes.DISPLAY_MATH_END
+    );
+
+    private static final TokenSet LATEX_ENVIRONMENT_DELIM = TokenSet.create(
+            LatexTypes.BEGIN_COMMAND, LatexTypes.END_COMMAND
     );
 
     private SpacingBuilder spacingBuilder;
@@ -57,6 +60,12 @@ public class LatexBlock extends AbstractBlock {
                 }
 
             }
+            else if (myNode.getElementType() == LatexTypes.ENVIRONMENT) {
+                // Skip \begin and \end
+                if (child != myNode.getFirstChildNode() && child != myNode.getLastChildNode()) {
+                    indent = Indent.getNormalIndent(true);
+                }
+            }
 
             if (child.getElementType() != TokenType.WHITE_SPACE) {
                 blocks.add(new LatexBlock(child, wrap, align, indent, spacingBuilder));
@@ -79,11 +88,11 @@ public class LatexBlock extends AbstractBlock {
         if (myNode.getElementType() == LatexTypes.DISPLAY_MATH) {
             return new ChildAttributes(Indent.getNormalIndent(), null);
         }
-        else if (myNode.getPsi() instanceof LatexFile) {
-            return new ChildAttributes(Indent.getNoneIndent(), null);
+        else if (myNode.getElementType() == LatexTypes.ENVIRONMENT) {
+            return new ChildAttributes(Indent.getNormalIndent(), null);
         }
 
-        return new ChildAttributes(null, null);
+        return new ChildAttributes(Indent.getNoneIndent(), null);
     }
 
     @Nullable

--- a/src/nl/rubensten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/rubensten/texifyidea/grammar/Latex.bnf
@@ -18,6 +18,8 @@
         DISPLAY_MATH_END='\]'
         INLINE_MATH_START='$'
         INLINE_MATH_END='$'
+        BEGIN_TOKEN='\begin'
+        END_TOKEN='\end'
         COMMAND_TOKEN='regexp:\\([a-zA-Z]+|.|\n|\r)'
         COMMENT_TOKEN='regexp:%[^\r\n]*'
         STAR='*'
@@ -31,9 +33,15 @@ latexFile ::= content*
 
 content ::= no_math_content | math_environment
 
-no_math_content ::= comment | commands | group | open_group | NORMAL_TEXT
+no_math_content ::= comment | environment | commands | group | open_group | NORMAL_TEXT
+
+environment ::= begin_command content* end_command
 
 commands ::= COMMAND_TOKEN STAR? parameter*
+
+begin_command ::= BEGIN_TOKEN STAR? parameter*
+
+end_command ::= END_TOKEN STAR? parameter*
 
 parameter ::= optional_param | required_param
 

--- a/src/nl/rubensten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/rubensten/texifyidea/grammar/LatexLexer.flex
@@ -32,6 +32,8 @@ OPEN_BRACE="{"
 CLOSE_BRACE="}"
 
 WHITE_SPACE=[ \t\n\x0B\f\r]+
+BEGIN_TOKEN="\\begin"
+END_TOKEN="\\end"
 COMMAND_TOKEN=\\([a-zA-Z]+|.|\n|\r)
 COMMENT_TOKEN=%[^\r\n]*
 NORMAL_TEXT=[^\\{}%\[\]$]+
@@ -58,6 +60,8 @@ NORMAL_TEXT=[^\\{}%\[\]$]+
 "}"                  { return CLOSE_BRACE; }
 
 {WHITE_SPACE}        { return WHITE_SPACE; }
+{BEGIN_TOKEN}        { return BEGIN_TOKEN; }
+{END_TOKEN}          { return END_TOKEN; }
 {COMMAND_TOKEN}      { return COMMAND_TOKEN; }
 {COMMENT_TOKEN}      { return COMMENT_TOKEN; }
 {NORMAL_TEXT}        { return NORMAL_TEXT; }

--- a/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.tree.TokenSet;
 import nl.rubensten.texifyidea.LatexLexerAdapter;
 import nl.rubensten.texifyidea.psi.LatexTypes;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,6 @@ import org.jetbrains.annotations.NotNull;
  * @author Ruben Schellekens, Sten Wessel
  */
 public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
-
     /*
      * TextAttributesKeys
      */
@@ -21,53 +21,51 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
             "LATEX_BRACES",
             DefaultLanguageHighlighterColors.BRACES
     );
-
     public static final TextAttributesKey BRACKETS = TextAttributesKey.createTextAttributesKey(
             "LATEX_BRACKETS",
             DefaultLanguageHighlighterColors.BRACKETS
     );
-
     public static final TextAttributesKey OPTIONAL_PARAM = TextAttributesKey.createTextAttributesKey(
             "LATEX_OPTIONAL_PARAM",
             DefaultLanguageHighlighterColors.PARAMETER
     );
-
     public static final TextAttributesKey COMMAND = TextAttributesKey.createTextAttributesKey(
             "LATEX_COMMAND",
             DefaultLanguageHighlighterColors.KEYWORD
     );
-
     public static final TextAttributesKey COMMAND_MATH_INLINE = TextAttributesKey.createTextAttributesKey(
             "LATEX_COMMAND_MATH_INLINE",
             DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE
     );
-
     public static final TextAttributesKey COMMAND_MATH_DISPLAY = TextAttributesKey
             .createTextAttributesKey(
             "LATEX_COMMAND_MATH_DISPLAY",
             DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE
     );
-
     public static final TextAttributesKey COMMENT = TextAttributesKey.createTextAttributesKey(
             "LATEX_COMMENT",
             DefaultLanguageHighlighterColors.LINE_COMMENT
     );
-
     public static final TextAttributesKey INLINE_MATH = TextAttributesKey.createTextAttributesKey(
             "LATEX_INLINE_MATH",
             DefaultLanguageHighlighterColors.STRING
     );
-
     public static final TextAttributesKey DISPLAY_MATH = TextAttributesKey.createTextAttributesKey(
             "LATEX_DISPLAY_MATH",
             DefaultLanguageHighlighterColors.STRING
     );
-
     public static final TextAttributesKey STAR = TextAttributesKey.createTextAttributesKey(
             "LATEX_STAR",
             DefaultLanguageHighlighterColors.DOT
     );
-
+    /*
+     * TokenSets
+     */
+    private static final TokenSet COMMAND_TOKENS = TokenSet.create(
+            LatexTypes.COMMAND_TOKEN,
+            LatexTypes.BEGIN_TOKEN,
+            LatexTypes.END_TOKEN
+    );
     /*
      * TextAttributeKey[]s
      */
@@ -125,7 +123,7 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
             return COMMENT_KEYS;
         }
         // Commands
-        else if (tokenType.equals(LatexTypes.COMMAND_TOKEN)) {
+        else if (COMMAND_TOKENS.contains(tokenType)) {
             return COMMAND_KEYS;
         }
         // Math environment


### PR DESCRIPTION
Fixes issue #16.

Automatically indent within LaTeX environments. As a bonus, the auto reformatter will indent environment contents as well.

Compatibility note: to accomplish this, the grammar needed to be changed such that `\begin` and `\end` could be distinguished from other commands at token level and hence in the parse tree.