### PR TITLE
Caret run over closing `$` in inline math environment

### DIFF
--- a/src/nl/rubensten/texifyidea/highlighting/LatexTypedHandler.java
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexTypedHandler.java
@@ -5,10 +5,14 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.highlighter.EditorHighlighter;
 import com.intellij.openapi.editor.highlighter.HighlighterIterator;
+import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.util.PsiTreeUtil;
 import nl.rubensten.texifyidea.file.LatexFile;
+import nl.rubensten.texifyidea.psi.LatexInlineMath;
 import nl.rubensten.texifyidea.psi.LatexTypes;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,9 +22,25 @@ import org.jetbrains.annotations.NotNull;
 public class LatexTypedHandler extends TypedHandlerDelegate {
 
     @Override
+    public Result beforeCharTyped(char c, Project project, Editor editor, PsiFile file, FileType fileType) {
+        if (file instanceof LatexFile) {
+            if (c == '$') {
+                PsiElement element = file.findElementAt(editor.getCaretModel().getOffset());
+                LatexInlineMath parent = PsiTreeUtil.getParentOfType(element, LatexInlineMath.class);
+                if (parent != null && (parent.getTextLength() > 2)) {
+                    // Non-empty contents
+                    editor.getCaretModel().moveCaretRelatively(1, 0, false, false, true);
+                    return Result.STOP;
+                }
+            }
+        }
+
+        return Result.CONTINUE;
+    }
+
+    @Override
     public Result charTyped(char c, Project project, @NotNull Editor editor, @NotNull PsiFile
             file) {
-        Result result = Result.CONTINUE;
 
         if (file instanceof LatexFile) {
             if (c == '$') {
@@ -44,7 +64,7 @@ public class LatexTypedHandler extends TypedHandlerDelegate {
     }
 
     /**
-     * Upon typing {@code \[}, inserts the closing delimiter {@code \[}.
+     * Upon typing {@code \[}, inserts the closing delimiter {@code \]}.
      */
     private Result insertDisplayMathClose(char c, Editor editor) {
         IElementType tokenType = getTypedTokenType(editor);


### PR DESCRIPTION
Closes #15.

Note: this ignores display math environment support with primitive `$$ ... $$` delimiters for now, as inserting `$$<cursor>$$` is not easily achievable anymore. However, this will come when such display math environments are supported by the parser.