### PR TITLE
Live template for environments

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -136,6 +136,10 @@
         <internalFileTemplate name="LaTeX Document class"/>
 
         <fileTemplateGroup implementation="nl.rubensten.texifyidea.templates.LatexTemplatesFactory"/>
+        
+        <!-- Live templates -->
+        <defaultLiveTemplatesProvider implementation="nl.rubensten.texifyidea.templates.LatexLiveTemplateProvider"/>
+        <liveTemplateContext implementation="nl.rubensten.texifyidea.templates.LatexContext"/>
 
         <!-- Settings -->
         <colorSettingsPage implementation="nl.rubensten.texifyidea.highlighting.LatexColorSettingsPage"/>

--- a/resources/liveTemplates/LaTeX.xml
+++ b/resources/liveTemplates/LaTeX.xml
@@ -1,0 +1,8 @@
+<templateSet group="LaTeX">
+    <template name="\begin{}" value="\begin{$ENVNAME$}&#10;    $END$&#10;\end{$ENVNAME$}" description="Starts a new environment." toReformat="true" toShortenFQNames="false">
+        <variable name="ENVNAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="LATEX" value="true" />
+        </context>
+    </template>
+</templateSet>

--- a/resources/liveTemplates/hidden/LaTeX.xml
+++ b/resources/liveTemplates/hidden/LaTeX.xml
@@ -1,5 +1,5 @@
 <templateSet group="LaTeX">
-    <template name="\begin{}" value="\begin{$ENVNAME$}&#10;    $END$&#10;\end{$ENVNAME$}" description="Starts a new environment." toReformat="true" toShortenFQNames="false">
+    <template id="LATEX.begin" name="begin" value="{$ENVNAME$}&#10;    $END$&#10;\end{$ENVNAME$}" description="Starts a new environment." toReformat="true" toShortenFQNames="false">
         <variable name="ENVNAME" expression="" defaultValue="" alwaysStopAt="true" />
         <context>
             <option name="LATEX" value="true" />

--- a/resources/liveTemplates/hidden/LaTeX.xml
+++ b/resources/liveTemplates/hidden/LaTeX.xml
@@ -1,6 +1,6 @@
 <templateSet group="LaTeX">
     <template id="LATEX.begin" name="begin" value="{$ENVNAME$}&#10;    $END$&#10;\end{$ENVNAME$}" description="Starts a new environment." toReformat="true" toShortenFQNames="false">
-        <variable name="ENVNAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ENVNAME" expression="complete()" defaultValue="" alwaysStopAt="true" />
         <context>
             <option name="LATEX" value="true" />
         </context>

--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -25,39 +25,51 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
     }
 
     @Override
-    protected void addCompletions(@NotNull CompletionParameters parameters, ProcessingContext
-            context, @NotNull CompletionResultSet result) {
-
-        if (mode == LatexMode.NORMAL) {
-            result.addAllElements(ContainerUtil.map2List(
-                    LatexNoMathCommand.values(),
-                    cmd -> LookupElementBuilder.create(cmd, cmd.getCommand())
-                            .withPresentableText(cmd.getCommandDisplay())
-                            .bold()
-                            .withTailText(cmd.getArgumentsDisplay(), true)
-                            .withTypeText(cmd.getDisplay())
-                            .withInsertHandler(new LatexNoMathInsertHandler())
-            ));
-
+    protected void addCompletions(@NotNull CompletionParameters parameters,
+                                  ProcessingContext context, @NotNull CompletionResultSet result) {
+        switch (mode) {
+            case NORMAL:
+                addNormalCommands(result);
+                break;
+            case MATH:
+                addMathCommands(result);
+                break;
+            case ENVIRONMENT_NAME:
+                addEnvironments(result);
+                break;
         }
-        else if (mode == LatexMode.MATH) {
-            result.addAllElements(ContainerUtil.map2List(
-                    LatexMathCommand.values(),
-                    cmd -> LookupElementBuilder.create(cmd, cmd.getCommand())
-                            .withPresentableText(cmd.getCommandDisplay())
-                            .bold()
-                            .withTailText(cmd.getArgumentsDisplay(), true)
-                            .withTypeText(cmd.getDisplay())
-            ));
 
-        }
-        else if (mode == LatexMode.ENVIRONMENT_NAME) {
-            result.addAllElements(ContainerUtil.map2List(
-                    LatexNoMathEnvironment.values(),
-                    cmd -> LookupElementBuilder.create(cmd, cmd.getName())
-                            .withPresentableText(cmd.getName())
-            ));
-        }
         result.addLookupAdvertisement("Don't use \\\\ outside of tabular or math mode, it's evil.");
+    }
+
+    private void addNormalCommands(CompletionResultSet result) {
+        result.addAllElements(ContainerUtil.map2List(
+                LatexNoMathCommand.values(),
+                cmd -> LookupElementBuilder.create(cmd, cmd.getCommand())
+                        .withPresentableText(cmd.getCommandDisplay())
+                        .bold()
+                        .withTailText(cmd.getArgumentsDisplay(), true)
+                        .withTypeText(cmd.getDisplay())
+                        .withInsertHandler(new LatexNoMathInsertHandler())
+        ));
+    }
+
+    private void addMathCommands(CompletionResultSet result) {
+        result.addAllElements(ContainerUtil.map2List(
+                LatexMathCommand.values(),
+                cmd -> LookupElementBuilder.create(cmd, cmd.getCommand())
+                        .withPresentableText(cmd.getCommandDisplay())
+                        .bold()
+                        .withTailText(cmd.getArgumentsDisplay(), true)
+                        .withTypeText(cmd.getDisplay())
+        ));
+    }
+
+    private void addEnvironments(CompletionResultSet result) {
+        result.addAllElements(ContainerUtil.map2List(
+                LatexNoMathEnvironment.values(),
+                cmd -> LookupElementBuilder.create(cmd, cmd.getName())
+                        .withPresentableText(cmd.getName())
+        ));
     }
 }

--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.util.ProcessingContext;
 import com.intellij.util.containers.ContainerUtil;
+import nl.rubensten.texifyidea.completion.handlers.LatexNoMathInsertHandler;
 import nl.rubensten.texifyidea.lang.LatexMathCommand;
 import nl.rubensten.texifyidea.lang.LatexMode;
 import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
@@ -34,6 +35,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
                             .bold()
                             .withTailText(cmd.getArgumentsDisplay(), true)
                             .withTypeText(cmd.getDisplay())
+                            .withInsertHandler(new LatexNoMathInsertHandler())
             ));
 
         }

--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -10,6 +10,7 @@ import nl.rubensten.texifyidea.completion.handlers.LatexNoMathInsertHandler;
 import nl.rubensten.texifyidea.lang.LatexMathCommand;
 import nl.rubensten.texifyidea.lang.LatexMode;
 import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
+import nl.rubensten.texifyidea.lang.LatexNoMathEnvironment;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -49,6 +50,13 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
                             .withTypeText(cmd.getDisplay())
             ));
 
+        }
+        else if (mode == LatexMode.ENVIRONMENT_NAME) {
+            result.addAllElements(ContainerUtil.map2List(
+                    LatexNoMathEnvironment.values(),
+                    cmd -> LookupElementBuilder.create(cmd, cmd.getName())
+                            .withPresentableText(cmd.getName())
+            ));
         }
         result.addLookupAdvertisement("Don't use \\\\ outside of tabular or math mode, it's evil.");
     }

--- a/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
@@ -5,7 +5,9 @@ import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.patterns.PlatformPatterns;
 import nl.rubensten.texifyidea.LatexLanguage;
 import nl.rubensten.texifyidea.lang.LatexMode;
+import nl.rubensten.texifyidea.psi.LatexBeginCommand;
 import nl.rubensten.texifyidea.psi.LatexMathEnvironment;
+import nl.rubensten.texifyidea.psi.LatexRequiredParam;
 import nl.rubensten.texifyidea.psi.LatexTypes;
 
 /**
@@ -23,6 +25,15 @@ public class LatexCompletionContributor extends CompletionContributor {
                 CompletionType.BASIC,
                 PlatformPatterns.psiElement(LatexTypes.COMMAND_TOKEN).andNot(PlatformPatterns.psiElement().inside(LatexMathEnvironment.class)).withLanguage(LatexLanguage.INSTANCE),
                 new LatexCommandProvider(LatexMode.NORMAL)
+        );
+
+        extend(
+                CompletionType.BASIC,
+                PlatformPatterns.psiElement(LatexTypes.NORMAL_TEXT)
+                        .inside(LatexRequiredParam.class)
+                        .inside(LatexBeginCommand.class)
+                        .withLanguage(LatexLanguage.INSTANCE),
+                new LatexCommandProvider(LatexMode.ENVIRONMENT_NAME)
         );
     }
 }

--- a/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
@@ -14,16 +14,21 @@ import nl.rubensten.texifyidea.psi.LatexTypes;
  * @author Sten Wessel
  */
 public class LatexCompletionContributor extends CompletionContributor {
+
     public LatexCompletionContributor() {
         extend(
-            CompletionType.BASIC,
-            PlatformPatterns.psiElement(LatexTypes.COMMAND_TOKEN).inside(LatexMathEnvironment.class).withLanguage(LatexLanguage.INSTANCE),
-            new LatexCommandProvider(LatexMode.MATH)
+                CompletionType.BASIC,
+                PlatformPatterns.psiElement(LatexTypes.COMMAND_TOKEN)
+                        .inside(LatexMathEnvironment.class)
+                        .withLanguage(LatexLanguage.INSTANCE),
+                new LatexCommandProvider(LatexMode.MATH)
         );
 
         extend(
                 CompletionType.BASIC,
-                PlatformPatterns.psiElement(LatexTypes.COMMAND_TOKEN).andNot(PlatformPatterns.psiElement().inside(LatexMathEnvironment.class)).withLanguage(LatexLanguage.INSTANCE),
+                PlatformPatterns.psiElement(LatexTypes.COMMAND_TOKEN)
+                        .andNot(PlatformPatterns.psiElement().inside(LatexMathEnvironment.class))
+                        .withLanguage(LatexLanguage.INSTANCE),
                 new LatexCommandProvider(LatexMode.NORMAL)
         );
 

--- a/src/nl/rubensten/texifyidea/completion/handlers/LatexNoMathInsertHandler.java
+++ b/src/nl/rubensten/texifyidea/completion/handlers/LatexNoMathInsertHandler.java
@@ -1,0 +1,24 @@
+package nl.rubensten.texifyidea.completion.handlers;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.template.Template;
+import com.intellij.codeInsight.template.TemplateManager;
+import com.intellij.codeInsight.template.impl.TemplateSettings;
+import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
+
+/**
+ * @author Sten Wessel
+ */
+public class LatexNoMathInsertHandler implements InsertHandler<LookupElement> {
+
+    @Override
+    public void handleInsert(InsertionContext context, LookupElement item) {
+        LatexNoMathCommand command = (LatexNoMathCommand)item.getObject();
+        if (command == LatexNoMathCommand.BEGIN) {
+            Template template = TemplateSettings.getInstance().getTemplateById("LATEX.begin");
+            TemplateManager.getInstance(context.getProject()).startTemplate(context.getEditor(), template);
+        }
+    }
+}

--- a/src/nl/rubensten/texifyidea/completion/handlers/LatexNoMathInsertHandler.java
+++ b/src/nl/rubensten/texifyidea/completion/handlers/LatexNoMathInsertHandler.java
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.template.Template;
 import com.intellij.codeInsight.template.TemplateManager;
 import com.intellij.codeInsight.template.impl.TemplateSettings;
+import com.intellij.openapi.editor.Editor;
 import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
 
 /**
@@ -16,9 +17,23 @@ public class LatexNoMathInsertHandler implements InsertHandler<LookupElement> {
     @Override
     public void handleInsert(InsertionContext context, LookupElement item) {
         LatexNoMathCommand command = (LatexNoMathCommand)item.getObject();
-        if (command == LatexNoMathCommand.BEGIN) {
-            Template template = TemplateSettings.getInstance().getTemplateById("LATEX.begin");
-            TemplateManager.getInstance(context.getProject()).startTemplate(context.getEditor(), template);
+
+        switch (command) {
+            case BEGIN:
+                insertBegin(context);
+                break;
         }
+    }
+
+    /**
+     * Inserts the {@code LATEX.begin} live template.
+     */
+    private void insertBegin(InsertionContext context) {
+        TemplateSettings templateSettings = TemplateSettings.getInstance();
+        Template template = templateSettings.getTemplateById("LATEX.begin");
+
+        Editor editor = context.getEditor();
+        TemplateManager templateManager = TemplateManager.getInstance(context.getProject());
+        templateManager.startTemplate(editor, template);
     }
 }

--- a/src/nl/rubensten/texifyidea/lang/LatexMode.java
+++ b/src/nl/rubensten/texifyidea/lang/LatexMode.java
@@ -5,5 +5,6 @@ package nl.rubensten.texifyidea.lang;
  */
 public enum LatexMode {
     NORMAL,
-    MATH
+    MATH,
+    ENVIRONMENT_NAME,
 }

--- a/src/nl/rubensten/texifyidea/templates/LatexContext.java
+++ b/src/nl/rubensten/texifyidea/templates/LatexContext.java
@@ -1,0 +1,21 @@
+package nl.rubensten.texifyidea.templates;
+
+import com.intellij.codeInsight.template.TemplateContextType;
+import com.intellij.psi.PsiFile;
+import nl.rubensten.texifyidea.file.LatexFile;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Sten Wessel
+ */
+public class LatexContext extends TemplateContextType {
+
+    protected LatexContext() {
+        super("LATEX", "LaTeX");
+    }
+
+    @Override
+    public boolean isInContext(@NotNull PsiFile file, int offset) {
+        return file instanceof LatexFile;
+    }
+}

--- a/src/nl/rubensten/texifyidea/templates/LatexLiveTemplateProvider.java
+++ b/src/nl/rubensten/texifyidea/templates/LatexLiveTemplateProvider.java
@@ -1,0 +1,21 @@
+package nl.rubensten.texifyidea.templates;
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author Sten Wessel
+ */
+public class LatexLiveTemplateProvider implements DefaultLiveTemplatesProvider {
+
+    @Override
+    public String[] getDefaultLiveTemplateFiles() {
+        return new String[]{"liveTemplates/LaTeX"};
+    }
+
+    @Nullable
+    @Override
+    public String[] getHiddenLiveTemplateFiles() {
+        return new String[0];
+    }
+}

--- a/src/nl/rubensten/texifyidea/templates/LatexLiveTemplateProvider.java
+++ b/src/nl/rubensten/texifyidea/templates/LatexLiveTemplateProvider.java
@@ -1,6 +1,7 @@
 package nl.rubensten.texifyidea.templates;
 
 import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider;
+import nl.rubensten.texifyidea.util.Constants;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -10,12 +11,14 @@ public class LatexLiveTemplateProvider implements DefaultLiveTemplatesProvider {
 
     @Override
     public String[] getDefaultLiveTemplateFiles() {
-        return new String[0];
+        return Constants.EMPTY_STRING_ARRAY;
     }
 
     @Nullable
     @Override
     public String[] getHiddenLiveTemplateFiles() {
-        return new String[]{"liveTemplates/hidden/LaTeX"};
+        return new String[] {
+                "liveTemplates/hidden/LaTeX"
+        };
     }
 }

--- a/src/nl/rubensten/texifyidea/templates/LatexLiveTemplateProvider.java
+++ b/src/nl/rubensten/texifyidea/templates/LatexLiveTemplateProvider.java
@@ -10,12 +10,12 @@ public class LatexLiveTemplateProvider implements DefaultLiveTemplatesProvider {
 
     @Override
     public String[] getDefaultLiveTemplateFiles() {
-        return new String[]{"liveTemplates/LaTeX"};
+        return new String[0];
     }
 
     @Nullable
     @Override
     public String[] getHiddenLiveTemplateFiles() {
-        return new String[0];
+        return new String[]{"liveTemplates/hidden/LaTeX"};
     }
 }


### PR DESCRIPTION
To make life (much) easier, environment autocomplete has arrived! Upon inserting `\begin` from autocomplete, now `\end` will be inserted as well. In addition, common environment names are being suggested.

![autocomplete for environments](https://cloud.githubusercontent.com/assets/11046840/23410610/184b39d4-fdd0-11e6-9099-b558f8d40301.png)
