### PR TITLE
Folding for environments.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -152,6 +152,7 @@
 
         <!-- Editor -->
         <lang.foldingBuilder language="Latex" implementationClass="nl.rubensten.texifyidea.folding.LatexMathSymbolFoldingBuilder"/>
+        <lang.foldingBuilder language="Latex" implementationClass="nl.rubensten.texifyidea.folding.LatexEnvironmentFoldingBuilder"/>
         <lang.formatter language="Latex" implementationClass="nl.rubensten.texifyidea.formatting.LatexFormattingModelBuilder"/>
         <completion.contributor language="Latex" implementationClass="nl.rubensten.texifyidea.completion.LatexCompletionContributor"/>
         <enterHandlerDelegate implementation="nl.rubensten.texifyidea.insight.LatexEnterBetweenBracesHandler"/>

--- a/src/nl/rubensten/texifyidea/folding/LatexEnvironmentFoldingBuilder.java
+++ b/src/nl/rubensten/texifyidea/folding/LatexEnvironmentFoldingBuilder.java
@@ -1,0 +1,57 @@
+package nl.rubensten.texifyidea.folding;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.folding.FoldingBuilderEx;
+import com.intellij.lang.folding.FoldingDescriptor;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import nl.rubensten.texifyidea.psi.LatexEnvironment;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Adds folding regions for LaTeX environments.
+ * <p>
+ * Enables folding of {@code \begin{environment} ... \end{environment}}.
+ *
+ * @author Sten Wessel
+ */
+public class LatexEnvironmentFoldingBuilder extends FoldingBuilderEx {
+
+    @NotNull
+    @Override
+    public FoldingDescriptor[] buildFoldRegions(@NotNull PsiElement root, @NotNull Document
+            document, boolean quick) {
+        List<FoldingDescriptor> descriptors = new ArrayList<>();
+        Collection<LatexEnvironment> envs = PsiTreeUtil.findChildrenOfType(root,
+                                                                           LatexEnvironment.class);
+
+        for (LatexEnvironment env : envs) {
+            // Get content offsets.
+            // Uses the commands instead of the actual contents as they may be empty.
+            int start = env.getBeginCommand().getTextRange().getEndOffset();
+            int end = env.getEndCommand().getTextRange().getStartOffset();
+
+            descriptors.add(new FoldingDescriptor(env, new TextRange(start, end)));
+        }
+
+        return descriptors.toArray(new FoldingDescriptor[descriptors.size()]);
+    }
+
+    @Override
+    public boolean isCollapsedByDefault(@NotNull ASTNode node) {
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public String getPlaceholderText(@NotNull ASTNode node) {
+        return "...";
+    }
+}


### PR DESCRIPTION
Expand and collapse of LaTeX environments. Useful for when your document is so complex and large that you have to hide parts of it from yourself.

Supports nested environments as well.

![image](https://cloud.githubusercontent.com/assets/11046840/23467989/d21275a6-fe9f-11e6-8914-f519133e5562.png)