### PR TITLE
Parentheses matching

### DIFF
--- a/gen/nl/rubensten/texifyidea/grammar/LatexLexer.java
+++ b/gen/nl/rubensten/texifyidea/grammar/LatexLexer.java
@@ -53,9 +53,9 @@ public class LatexLexer implements FlexLexer {
 
   /* The ZZ_CMAP_A table has 320 entries */
   static final char ZZ_CMAP_A[] = zzUnpackCMap(
-    "\11\0\1\2\1\1\2\7\1\1\22\0\1\2\3\0\1\22\1\21\4\0\1\23\26\0\32\17\1\3\1\10"+
-    "\1\4\3\0\1\17\1\11\1\17\1\16\1\12\1\17\1\13\1\17\1\14\4\17\1\15\14\17\1\5"+
-    "\1\0\1\6\7\0\1\20\242\0\2\20\26\0");
+    "\11\0\1\2\1\1\2\11\1\1\22\0\1\2\3\0\1\24\1\23\2\0\1\7\1\10\1\25\26\0\32\21"+
+    "\1\3\1\12\1\4\3\0\1\21\1\13\1\21\1\20\1\14\1\21\1\15\1\21\1\16\4\21\1\17\14"+
+    "\21\1\5\1\0\1\6\7\0\1\22\242\0\2\22\26\0");
 
   /** 
    * Translates DFA states to action switch labels.
@@ -64,11 +64,11 @@ public class LatexLexer implements FlexLexer {
 
   private static final String ZZ_ACTION_PACKED_0 =
     "\2\0\1\1\1\2\1\3\1\4\1\5\1\6\1\7"+
-    "\1\10\1\11\1\12\1\13\1\14\1\15\1\16\6\14"+
-    "\1\17\1\14\1\20";
+    "\1\10\1\11\1\12\1\13\1\14\1\15\1\16\1\17"+
+    "\1\20\6\16\1\21\1\16\1\22";
 
   private static int [] zzUnpackAction() {
-    int [] result = new int[25];
+    int [] result = new int[27];
     int offset = 0;
     offset = zzUnpackAction(ZZ_ACTION_PACKED_0, offset, result);
     return result;
@@ -93,13 +93,13 @@ public class LatexLexer implements FlexLexer {
   private static final int [] ZZ_ROWMAP = zzUnpackRowMap();
 
   private static final String ZZ_ROWMAP_PACKED_0 =
-    "\0\0\0\24\0\50\0\74\0\120\0\120\0\120\0\120"+
-    "\0\144\0\170\0\120\0\50\0\120\0\120\0\120\0\120"+
-    "\0\214\0\240\0\264\0\310\0\334\0\360\0\264\0\u0104"+
-    "\0\264";
+    "\0\0\0\26\0\54\0\102\0\130\0\130\0\130\0\130"+
+    "\0\130\0\130\0\156\0\204\0\130\0\54\0\130\0\130"+
+    "\0\130\0\130\0\232\0\260\0\306\0\334\0\362\0\u0108"+
+    "\0\306\0\u011e\0\306";
 
   private static int [] zzUnpackRowMap() {
-    int [] result = new int[25];
+    int [] result = new int[27];
     int offset = 0;
     offset = zzUnpackRowMap(ZZ_ROWMAP_PACKED_0, offset, result);
     return result;
@@ -122,19 +122,20 @@ public class LatexLexer implements FlexLexer {
   private static final int [] ZZ_TRANS = zzUnpackTrans();
 
   private static final String ZZ_TRANS_PACKED_0 =
-    "\1\3\2\4\1\5\1\6\1\7\1\10\1\4\1\11"+
-    "\10\3\1\12\1\13\1\14\1\3\2\4\1\5\1\6"+
-    "\1\7\1\10\1\4\1\11\10\3\1\12\1\15\1\14"+
-    "\3\3\4\0\1\3\1\0\10\3\2\0\2\3\2\4"+
-    "\4\0\1\4\1\0\10\3\2\0\1\3\24\0\3\16"+
-    "\1\17\1\20\2\16\1\0\1\16\1\21\1\22\5\23"+
-    "\1\0\3\16\1\12\1\0\22\12\11\0\1\23\1\24"+
-    "\5\23\15\0\4\23\1\25\2\23\15\0\7\23\15\0"+
-    "\2\23\1\26\4\23\15\0\5\23\1\27\1\23\15\0"+
-    "\3\23\1\30\3\23\15\0\4\23\1\31\2\23\4\0";
+    "\1\3\2\4\1\5\1\6\1\7\1\10\1\11\1\12"+
+    "\1\4\1\13\10\3\1\14\1\15\1\16\1\3\2\4"+
+    "\1\5\1\6\1\7\1\10\1\11\1\12\1\4\1\13"+
+    "\10\3\1\14\1\17\1\16\3\3\6\0\1\3\1\0"+
+    "\10\3\2\0\2\3\2\4\6\0\1\4\1\0\10\3"+
+    "\2\0\1\3\26\0\3\20\1\21\1\22\4\20\1\0"+
+    "\1\20\1\23\1\24\5\25\1\0\3\20\1\14\1\0"+
+    "\24\14\13\0\1\25\1\26\5\25\17\0\4\25\1\27"+
+    "\2\25\17\0\7\25\17\0\2\25\1\30\4\25\17\0"+
+    "\5\25\1\31\1\25\17\0\3\25\1\32\3\25\17\0"+
+    "\4\25\1\33\2\25\4\0";
 
   private static int [] zzUnpackTrans() {
-    int [] result = new int[280];
+    int [] result = new int[308];
     int offset = 0;
     offset = zzUnpackTrans(ZZ_TRANS_PACKED_0, offset, result);
     return result;
@@ -172,10 +173,10 @@ public class LatexLexer implements FlexLexer {
   private static final int [] ZZ_ATTRIBUTE = zzUnpackAttribute();
 
   private static final String ZZ_ATTRIBUTE_PACKED_0 =
-    "\2\0\2\1\4\11\2\1\1\11\1\1\4\11\11\1";
+    "\2\0\2\1\6\11\2\1\1\11\1\1\4\11\11\1";
 
   private static int [] zzUnpackAttribute() {
-    int [] result = new int[25];
+    int [] result = new int[27];
     int offset = 0;
     offset = zzUnpackAttribute(ZZ_ATTRIBUTE_PACKED_0, offset, result);
     return result;
@@ -485,67 +486,75 @@ public class LatexLexer implements FlexLexer {
           case 1: 
             { return NORMAL_TEXT;
             }
-          case 17: break;
+          case 19: break;
           case 2: 
             { return com.intellij.psi.TokenType.WHITE_SPACE;
             }
-          case 18: break;
+          case 20: break;
           case 3: 
             { return OPEN_BRACKET;
             }
-          case 19: break;
+          case 21: break;
           case 4: 
             { return CLOSE_BRACKET;
             }
-          case 20: break;
+          case 22: break;
           case 5: 
             { return OPEN_BRACE;
             }
-          case 21: break;
+          case 23: break;
           case 6: 
             { return CLOSE_BRACE;
             }
-          case 22: break;
-          case 7: 
-            { return com.intellij.psi.TokenType.BAD_CHARACTER;
-            }
-          case 23: break;
-          case 8: 
-            { return COMMENT_TOKEN;
-            }
           case 24: break;
-          case 9: 
-            { yybegin(INLINE_MATH); return INLINE_MATH_START;
+          case 7: 
+            { return OPEN_PAREN;
             }
           case 25: break;
-          case 10: 
-            { return STAR;
+          case 8: 
+            { return CLOSE_PAREN;
             }
           case 26: break;
-          case 11: 
-            { yybegin(YYINITIAL); return INLINE_MATH_END;
+          case 9: 
+            { return com.intellij.psi.TokenType.BAD_CHARACTER;
             }
           case 27: break;
-          case 12: 
-            { return COMMAND_TOKEN;
+          case 10: 
+            { return COMMENT_TOKEN;
             }
           case 28: break;
-          case 13: 
-            { return DISPLAY_MATH_START;
+          case 11: 
+            { yybegin(INLINE_MATH); return INLINE_MATH_START;
             }
           case 29: break;
-          case 14: 
-            { return DISPLAY_MATH_END;
+          case 12: 
+            { return STAR;
             }
           case 30: break;
-          case 15: 
-            { return END_TOKEN;
+          case 13: 
+            { yybegin(YYINITIAL); return INLINE_MATH_END;
             }
           case 31: break;
-          case 16: 
-            { return BEGIN_TOKEN;
+          case 14: 
+            { return COMMAND_TOKEN;
             }
           case 32: break;
+          case 15: 
+            { return DISPLAY_MATH_START;
+            }
+          case 33: break;
+          case 16: 
+            { return DISPLAY_MATH_END;
+            }
+          case 34: break;
+          case 17: 
+            { return END_TOKEN;
+            }
+          case 35: break;
+          case 18: 
+            { return BEGIN_TOKEN;
+            }
+          case 36: break;
           default:
             zzScanError(ZZ_NO_MATCH);
           }

--- a/gen/nl/rubensten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/rubensten/texifyidea/parser/LatexParser.java
@@ -352,7 +352,7 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // comment | environment | commands | group | open_group | NORMAL_TEXT
+  // comment | environment | commands | group | open_group | OPEN_PAREN | CLOSE_PAREN | NORMAL_TEXT
   public static boolean no_math_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "no_math_content")) return false;
     boolean r;
@@ -362,6 +362,8 @@ public class LatexParser implements PsiParser, LightPsiParser {
     if (!r) r = commands(b, l + 1);
     if (!r) r = group(b, l + 1);
     if (!r) r = open_group(b, l + 1);
+    if (!r) r = consumeToken(b, OPEN_PAREN);
+    if (!r) r = consumeToken(b, CLOSE_PAREN);
     if (!r) r = consumeToken(b, NORMAL_TEXT);
     exit_section_(b, l, m, r, false, null);
     return r;

--- a/gen/nl/rubensten/texifyidea/psi/LatexTypes.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexTypes.java
@@ -27,6 +27,7 @@ public interface LatexTypes {
   IElementType BEGIN_TOKEN = new LatexTokenType("\\begin");
   IElementType CLOSE_BRACE = new LatexTokenType("CLOSE_BRACE");
   IElementType CLOSE_BRACKET = new LatexTokenType("CLOSE_BRACKET");
+  IElementType CLOSE_PAREN = new LatexTokenType("CLOSE_PAREN");
   IElementType COMMAND_TOKEN = new LatexTokenType("COMMAND_TOKEN");
   IElementType COMMENT_TOKEN = new LatexTokenType("COMMENT_TOKEN");
   IElementType DISPLAY_MATH_END = new LatexTokenType("\\]");
@@ -37,6 +38,7 @@ public interface LatexTypes {
   IElementType NORMAL_TEXT = new LatexTokenType("NORMAL_TEXT");
   IElementType OPEN_BRACE = new LatexTokenType("OPEN_BRACE");
   IElementType OPEN_BRACKET = new LatexTokenType("OPEN_BRACKET");
+  IElementType OPEN_PAREN = new LatexTokenType("OPEN_PAREN");
   IElementType STAR = new LatexTokenType("*");
 
   class Factory {

--- a/src/nl/rubensten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/rubensten/texifyidea/grammar/Latex.bnf
@@ -33,7 +33,7 @@ latexFile ::= content*
 
 content ::= no_math_content | math_environment
 
-no_math_content ::= comment | environment | commands | group | open_group | NORMAL_TEXT
+no_math_content ::= comment | environment | commands | group | open_group | OPEN_PAREN | CLOSE_PAREN | NORMAL_TEXT
 
 environment ::= begin_command content* end_command
 

--- a/src/nl/rubensten/texifyidea/grammar/LatexLexer.flex
+++ b/src/nl/rubensten/texifyidea/grammar/LatexLexer.flex
@@ -30,13 +30,15 @@ OPEN_BRACKET="["
 CLOSE_BRACKET="]"
 OPEN_BRACE="{"
 CLOSE_BRACE="}"
+OPEN_PAREN="("
+CLOSE_PAREN=")"
 
 WHITE_SPACE=[ \t\n\x0B\f\r]+
 BEGIN_TOKEN="\\begin"
 END_TOKEN="\\end"
 COMMAND_TOKEN=\\([a-zA-Z]+|.|\n|\r)
 COMMENT_TOKEN=%[^\r\n]*
-NORMAL_TEXT=[^\\{}%\[\]$]+
+NORMAL_TEXT=[^\\{}%\[\]$\(\)]+
 
 %states INLINE_MATH
 %%
@@ -58,6 +60,8 @@ NORMAL_TEXT=[^\\{}%\[\]$]+
 "]"                  { return CLOSE_BRACKET; }
 "{"                  { return OPEN_BRACE; }
 "}"                  { return CLOSE_BRACE; }
+{OPEN_PAREN}         { return OPEN_PAREN; }
+{CLOSE_PAREN}        { return CLOSE_PAREN; }
 
 {WHITE_SPACE}        { return WHITE_SPACE; }
 {BEGIN_TOKEN}        { return BEGIN_TOKEN; }

--- a/src/nl/rubensten/texifyidea/highlighting/LatexPairedBraceMatcher.java
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexPairedBraceMatcher.java
@@ -18,6 +18,7 @@ public class LatexPairedBraceMatcher implements PairedBraceMatcher {
         return new BracePair[]{
                 new BracePair(LatexTypes.DISPLAY_MATH_START, LatexTypes.DISPLAY_MATH_END, true),
                 new BracePair(LatexTypes.INLINE_MATH_START, LatexTypes.INLINE_MATH_END, false),
+                new BracePair(LatexTypes.OPEN_PAREN, LatexTypes.CLOSE_PAREN, false),
                 new BracePair(LatexTypes.OPEN_BRACE, LatexTypes.CLOSE_BRACE, false),
                 new BracePair(LatexTypes.OPEN_BRACKET, LatexTypes.CLOSE_BRACKET, false),
         };


### PR DESCRIPTION
Fixes #38. Parentheses are now matched to a dedicated token type `OPEN_PAREN` and `CLOSE_PAREN` to make this possible.