### PR TITLE
Fixed #49: Replacing a command skips over the first required argument.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.java
+++ b/src/nl/rubensten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.java
@@ -72,7 +72,8 @@ public class LatexCommandArgumentInsertHandler implements InsertHandler<LookupEl
         int offset = caret.getOffset();
 
         // When not followed by {}, insert {}.
-        if (!document.getText(TextRange.from(offset, 1)).equals("{")) {
+        if (offset >= document.getTextLength() - 1 ||
+                !document.getText(TextRange.from(offset, 1)).equals("{")) {
             insertSquigglyBracketPair(editor, caret);
         }
         else {


### PR DESCRIPTION
# Changes
- When replacing a command via autocomplete, no `{}` will be inserted if there already are braces.
- Additionally, the cursor will skip to the end of the first required argument.

Awesome illustrating gif:

![ezgif-2-20d58e7e89](https://cloud.githubusercontent.com/assets/17410729/26405573/03629838-4096-11e7-8aaf-7eb3cf0f1b21.gif)
