### PR TITLE
Fixed #50: \input commands now show up as include in the structure view.

### DIFF
--- a/src/nl/rubensten/texifyidea/structure/LatexIncludePresentation.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexIncludePresentation.java
@@ -17,7 +17,8 @@ public class LatexIncludePresentation implements ItemPresentation {
 
     public LatexIncludePresentation(LatexCommands labelCommand) {
         if (!labelCommand.getCommandToken().getText().equals("\\include") &&
-                !labelCommand.getCommandToken().getText().equals("\\includeonly")) {
+                !labelCommand.getCommandToken().getText().equals("\\includeonly") &&
+                !labelCommand.getCommandToken().getText().equals("\\input")) {
             throw new IllegalArgumentException("command is no \\include(only)-command");
         }
 

--- a/src/nl/rubensten/texifyidea/structure/LatexPresentationFactory.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexPresentationFactory.java
@@ -28,6 +28,8 @@ public class LatexPresentationFactory {
                 return new LatexIncludePresentation(commands);
             case "\\includeonly":
                 return new LatexIncludePresentation(commands);
+            case "\\input":
+                return new LatexIncludePresentation(commands);
         }
 
         throw new IllegalArgumentException(

--- a/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
@@ -161,7 +161,7 @@ public class LatexStructureViewElement implements StructureViewTreeElement, Sort
     private void addIncludes(List<TreeElement> treeElements, List<LatexCommands> commands) {
         for (LatexCommands cmd : commands) {
             String name = cmd.getCommandToken().getText();
-            if (!name.equals("\\include") && !name.equals("\\includeonly")) {
+            if (!name.equals("\\include") && !name.equals("\\includeonly") && !name.equals("\\input")) {
                 continue;
             }
 

--- a/src/nl/rubensten/texifyidea/structure/filter/LatexIncludesFilter.java
+++ b/src/nl/rubensten/texifyidea/structure/filter/LatexIncludesFilter.java
@@ -22,7 +22,8 @@ public class LatexIncludesFilter implements Filter {
 
         LatexStructureViewCommandElement element = (LatexStructureViewCommandElement)treeElement;
         return !element.getCommandName().equals("\\include") &&
-                !element.getCommandName().equals("\\includeonly");
+                !element.getCommandName().equals("\\includeonly") &&
+                !element.getCommandName().equals("\\input");
     }
 
     @Override


### PR DESCRIPTION
# Changes
- See #50: `\input`-esque includes are now present in the structure view.

Screenshot:

![image](https://cloud.githubusercontent.com/assets/17410729/26405991/3e829a0c-4097-11e7-9a40-d0ca7ce7b349.png)
