### PR TITLE
Fixed #51: Directory completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Please bear in mind that this is just a side project for us.
 * Autocompletion form a predefined list of commands.
 * Commands defined in the project will also be added to the autocompletion list.
 * Autocompletion of defined labels (using `\label`).
+* Autocompletion for file names.
 * Brace matching for `{}`, `[]`, `\[\]` and `$$`.
 * Automatically inserts other half of `{}`, `[]`, `\[\]` and `$$`.
 * Most math commands get replaced by their unicode representation using folding.

--- a/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
@@ -78,6 +78,10 @@ public class LatexCompletionContributor extends CompletionContributor {
                                         psiElement, LatexCommands.class
                                 );
 
+                                if (command == null) {
+                                    return false;
+                                }
+
                                 String name = command.getCommandToken().getText();
                                 LatexNoMathCommand cmd = LatexNoMathCommand.get(name.substring(1)).orElse(null);
                                 if (cmd == null) {

--- a/src/nl/rubensten/texifyidea/completion/LatexFileProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexFileProvider.java
@@ -1,0 +1,132 @@
+package nl.rubensten.texifyidea.completion;
+
+import com.intellij.codeInsight.completion.CompletionParameters;
+import com.intellij.codeInsight.completion.CompletionProvider;
+import com.intellij.codeInsight.completion.CompletionResultSet;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.PlatformIcons;
+import com.intellij.util.ProcessingContext;
+import nl.rubensten.texifyidea.TexifyIcons;
+import nl.rubensten.texifyidea.completion.handlers.LatexReferenceInsertHandler;
+import nl.rubensten.texifyidea.util.Kindness;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * @author Ruben Schellekens
+ */
+public class LatexFileProvider extends CompletionProvider<CompletionParameters> {
+
+    private static final Pattern TRIM_SLASH = Pattern.compile("/[^/]*$");
+    private static final Pattern TRIM_BACK = Pattern.compile("\\.\\./");
+
+    LatexFileProvider() {
+    }
+
+    @Override
+    protected void addCompletions(@NotNull CompletionParameters parameters,
+                                  ProcessingContext context, @NotNull CompletionResultSet result) {
+        // Get base data.
+        VirtualFile baseFile = parameters.getOriginalFile().getVirtualFile();
+        VirtualFile baseDirectory = baseFile.getParent();
+        String autocompleteText = processAutocompleteText(parameters.getOriginalPosition().getText());
+
+        String directoryPath = baseDirectory.getPath() + "/" + autocompleteText;
+        VirtualFile searchDirectory = getByPath(directoryPath);
+
+        if (searchDirectory == null) {
+            autocompleteText = trimAutocompleteText(autocompleteText);
+            if (autocompleteText.length() == 0) {
+                searchDirectory = baseDirectory;
+            }
+            else {
+                searchDirectory = getByPath(baseDirectory.getPath() + "/" + autocompleteText);
+            }
+        }
+
+        if (autocompleteText.length() > 0 && !autocompleteText.endsWith("/")) {
+            return;
+        }
+
+        // Find stuff.
+        List<VirtualFile> directories = getContents(searchDirectory, true);
+        List<VirtualFile> files = getContents(searchDirectory, false);
+
+        // Add directories.
+        for (VirtualFile directory : directories) {
+            String directoryName = directory.getPresentableName();
+            result.addElement(
+                    LookupElementBuilder.create(noBack(autocompleteText) + directory.getName())
+                            .withPresentableText(directoryName)
+                            .withIcon(PlatformIcons.PACKAGE_ICON)
+            );
+        }
+
+        // Add return directory.
+        result.addElement(
+                LookupElementBuilder.create("..")
+                        .withIcon(PlatformIcons.PACKAGE_ICON)
+        );
+
+        // Add files.
+        for (VirtualFile file : files) {
+            String fileName = file.getPresentableName();
+            Icon icon = TexifyIcons.getIconFromExtension(file.getExtension());
+            result.addElement(
+                    LookupElementBuilder.create(noBack(autocompleteText) + file.getName())
+                            .withPresentableText(fileName)
+                            .withInsertHandler(new LatexReferenceInsertHandler())
+                            .withIcon(icon)
+            );
+        }
+
+        result.addLookupAdvertisement(Kindness.getKindWords());
+    }
+
+    private String noBack(String stuff) {
+        return TRIM_BACK.matcher(stuff).replaceAll("");
+    }
+
+    private String trimAutocompleteText(String autoCompleteText) {
+        if (!autoCompleteText.contains("/")) {
+            return "";
+        }
+
+        return TRIM_SLASH.matcher(autoCompleteText).replaceAll("/");
+    }
+
+    private String processAutocompleteText(String autocompleteText) {
+        String result = autocompleteText.endsWith("}") ?
+                autocompleteText.substring(0, autocompleteText.length() - 1) :
+                autocompleteText;
+
+        if (result.endsWith(".")) {
+            result = result.substring(0, result.length() - 1) + "/";
+        }
+
+        return result;
+    }
+
+    private VirtualFile getByPath(String path) {
+        LocalFileSystem fileSystem = LocalFileSystem.getInstance();
+        return fileSystem.findFileByPath(path);
+    }
+
+    private List<VirtualFile> getContents(VirtualFile base, boolean directory) {
+        List<VirtualFile> contents = new ArrayList<>();
+
+        for (VirtualFile file : base.getChildren()) {
+            if (file.isDirectory() == directory) {
+                contents.add(file);
+            }
+        }
+
+        return contents;
+    }
+}

--- a/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
@@ -187,8 +187,8 @@ public class LatexStructureViewElement implements StructureViewTreeElement, Sort
             }
 
             PsiFile psiFile = PsiManager.getInstance(element.getProject()).findFile(fileHuh.get());
-            if (!psiFile.getFileType().equals(LatexFileType.INSTANCE) && !psiFile.getFileType()
-                    .equals(StyleFileType.INSTANCE)) {
+            if (!LatexFileType.INSTANCE.equals(psiFile.getFileType()) &&
+                    !StyleFileType.INSTANCE.equals(psiFile.getFileType())) {
                 continue;
             }
 


### PR DESCRIPTION
# Changes
- Added autocomplete for files and directories for command arguments that take a file argument.
- When entered a directory, the window disappears and WONT reappear when adding a slash. You have to either use `CTRL`+`SPACE` or type the first letter to let it reappear. It does do silly things when using dots, however.
- Fixed a NPE when the structure view tries to get the structure of a non-existent include.

Screenshot:

![image](https://cloud.githubusercontent.com/assets/17410729/26426076/65bb365c-40d7-11e7-8ca9-ba4bce335afc.png)
