### PR TITLE
Custom compiler path

### DIFF
--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -39,9 +39,6 @@ public enum LatexCompiler {
                 command.add("pdflatex");
             }
             command.add("-file-line-error");
-            command.add("-time-statistics");
-            command.add("-c-style-errors");
-            command.add("-max-print-line=10000");
             command.add("-interaction=nonstopmode");
             command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
             command.add("-output-directory=" + moduleRoot.getPath() + "/out");

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -14,12 +14,14 @@ import java.util.List;
  */
 public enum LatexCompiler {
 
-    PDFLATEX("pdfLaTeX");
+    PDFLATEX("pdfLaTeX", "pdflatex");
 
     private String displayName;
+    private String executableName;
 
-    LatexCompiler(String displayName) {
+    LatexCompiler(String displayName, String executableName) {
         this.displayName = displayName;
+        this.executableName = executableName;
     }
 
     public List<String> getCommand(LatexRunConfiguration runConfig, Project project) {
@@ -31,7 +33,11 @@ public enum LatexCompiler {
         VirtualFile moduleRoot = fileIndex.getContentRootForFile(runConfig.getMainFile());
 
         if (this == PDFLATEX) {
-            command.add("pdflatex");
+            if (runConfig.getCompilerPath() != null) {
+                command.add(runConfig.getCompilerPath());
+            } else {
+                command.add("pdflatex");
+            }
             command.add("-file-line-error");
             command.add("-time-statistics");
             command.add("-c-style-errors");
@@ -48,6 +54,10 @@ public enum LatexCompiler {
         command.add(mainFile.getName());
 
         return command;
+    }
+
+    public String getExecutableName() {
+        return executableName;
     }
 
     @Override

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -78,7 +78,7 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
 
         // Read compiler custom path.
         String compilerPathRead = parent.getChildText(COMPILER_PATH);
-        this.compilerPath = compilerPathRead.isEmpty() ? null : compilerPathRead;
+        this.compilerPath = (compilerPathRead == null || compilerPathRead.isEmpty()) ? null : compilerPathRead;
 
         // Read main file.
         LocalFileSystem fileSystem = LocalFileSystem.getInstance();

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -28,6 +28,7 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
     private static final String OUTPUT_FORMAT = "output-format";
 
     private LatexCompiler compiler;
+    private String compilerPath = null;
     private VirtualFile mainFile;
     private boolean auxDir = true;
     private Format outputFormat = Format.PDF;
@@ -180,6 +181,14 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
 
     public void setSuggestedName() {
         setName(suggestedName());
+    }
+
+    public String getCompilerPath() {
+        return compilerPath;
+    }
+
+    public void setCompilerPath(String compilerPath) {
+        this.compilerPath = compilerPath;
     }
 
     @Override

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -23,6 +23,7 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
 
     private static final String TEXIFY_PARENT = "texify";
     private static final String COMPILER = "compiler";
+    private static final String COMPILER_PATH = "compiler-path";
     private static final String MAIN_FILE = "main-file";
     private static final String AUX_DIR = "aux-dir";
     private static final String OUTPUT_FORMAT = "output-format";
@@ -75,6 +76,10 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
             this.compiler = null;
         }
 
+        // Read compiler custom path.
+        String compilerPathRead = parent.getChildText(COMPILER_PATH);
+        this.compilerPath = compilerPathRead.isEmpty() ? null : compilerPathRead;
+
         // Read main file.
         LocalFileSystem fileSystem = LocalFileSystem.getInstance();
         String filePath = parent.getChildText(MAIN_FILE);
@@ -109,6 +114,11 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
         final Element compilerElt = new Element(COMPILER);
         compilerElt.setText(compiler == null ? "" : compiler.name());
         parent.addContent(compilerElt);
+
+        // Write compiler path.
+        final Element compilerPathElt = new Element(COMPILER_PATH);
+        compilerPathElt.setText(compilerPath == null ? "" : compilerPath);
+        parent.addContent(compilerPathElt);
 
         // Write main file.
         final Element mainFileElt = new Element(MAIN_FILE);
@@ -209,6 +219,7 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
     @Override
     public String toString() {
         return "LatexRunConfiguration{" + "compiler=" + compiler +
+                ", compilerPath=" + compilerPath +
                 ", mainFile=" + mainFile +
                 ", auxDir=" + auxDir +
                 ", outputFormat=" + outputFormat +

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -107,7 +107,7 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
         panel.add(compiler);
 
         // Optional custom path for compiler executable
-        enableCompilerPath = new JCheckBox("Select custom compiler executable path");
+        enableCompilerPath = new JCheckBox("Select custom compiler executable path (required on Mac OS X)");
         panel.add(enableCompilerPath);
 
         compilerPath = new TextFieldWithBrowseButton();

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -73,9 +73,7 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
         runConfiguration.setCompiler(chosenCompiler);
 
         // Apply custom compiler path if applicable
-        if (enableCompilerPath.isSelected()) {
-            runConfiguration.setCompilerPath(compilerPath.getText());
-        }
+        runConfiguration.setCompilerPath(enableCompilerPath.isSelected() ? compilerPath.getText() : null);
 
         // Apply main file.
         TextFieldWithBrowseButton txtFile = (TextFieldWithBrowseButton)mainFile.getComponent();
@@ -117,7 +115,7 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
                 new TextBrowseFolderListener(
                         new FileChooserDescriptor(true, false, false, false, false, false)
                             .withFileFilter(virtualFile -> virtualFile.getNameWithoutExtension().equals(((LatexCompiler)compilerField.getSelectedItem()).getExecutableName()))
-                            .withTitle("Choose " + ((LatexCompiler)compilerField.getSelectedItem()) + " executable")
+                            .withTitle("Choose " + compilerField.getSelectedItem() + " executable")
                 )
         );
         compilerPath.setEnabled(false);


### PR DESCRIPTION
Added the ability to specify a custom compiler executable path in run configurations. This should resolve #25, but I cannot test this beforehand since I have no OSX machine available right now.

A custom path must match the selected compiler. Only pdflatex is supported for now, which means that the base name of the executable file that is selected must equal `pdflatex`.

![image](https://user-images.githubusercontent.com/11046840/28041941-8f96412e-65cb-11e7-8f99-9bc24fe89bdc.png)
