### PR TITLE
Label reference 'Go to declaration'

### DIFF
--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexCommandsImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexCommandsImpl.java
@@ -3,10 +3,15 @@ package nl.rubensten.texifyidea.psi.impl;
 import java.util.List;
 
 import com.intellij.extapi.psi.StubBasedPsiElementBase;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.Computable;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.StubBasedPsiElement;
 import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.util.IncorrectOperationException;
 import nl.rubensten.texifyidea.index.stub.LatexCommandsStub;
+import nl.rubensten.texifyidea.reference.LatexLabelReference;
+import nl.rubensten.texifyidea.util.TexifyUtil;
 import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.PsiElement;
@@ -42,6 +47,20 @@ public class LatexCommandsImpl extends StubBasedPsiElementBase<LatexCommandsStub
         else {
             super.accept(visitor);
         }
+    }
+
+    @Override
+    public PsiReference getReference() {
+        LatexRequiredParam firstParam = ApplicationManager.getApplication().runReadAction((Computable<LatexRequiredParam>)() -> {
+            List<LatexRequiredParam> params = TexifyUtil.getRequiredParameters(this);
+            return params.isEmpty() ? null : params.get(0);
+        });
+
+        if (getCommandToken().getText().equals("\\ref") && firstParam != null) {
+            return new LatexLabelReference(this, firstParam);
+        }
+
+        return null;
     }
 
     @Override

--- a/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
@@ -47,25 +47,6 @@ public class LatexCompletionContributor extends CompletionContributor {
                 new LatexCommandProvider(LatexMode.ENVIRONMENT_NAME)
         );
 
-        // References.
-        extend(
-                CompletionType.BASIC,
-                PlatformPatterns.psiElement(LatexTypes.NORMAL_TEXT)
-                        .inside(LatexRequiredParam.class)
-                        .with(new PatternCondition<PsiElement>(null) {
-                            @Override
-                            public boolean accepts(@NotNull PsiElement psiElement, ProcessingContext processingContext) {
-                                LatexCommands command = LatexPsiUtil.getParentOfType(
-                                        psiElement, LatexCommands.class
-                                );
-                                return command != null &&
-                                        command.getCommandToken().getText().equals("\\ref");
-                            }
-                        })
-                        .withLanguage(LatexLanguage.INSTANCE),
-                new LatexReferenceProvider()
-        );
-
         // File names
         extend(
                 CompletionType.BASIC,

--- a/src/nl/rubensten/texifyidea/completion/LatexReferenceProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexReferenceProvider.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 /**
  * @author Ruben Schellekens
+ * @deprecated From b0.3 onward. Use {@link nl.rubensten.texifyidea.reference.LatexLabelReference} instead.
  */
 public class LatexReferenceProvider extends CompletionProvider<CompletionParameters> {
 

--- a/src/nl/rubensten/texifyidea/reference/LatexLabelReference.java
+++ b/src/nl/rubensten/texifyidea/reference/LatexLabelReference.java
@@ -61,10 +61,4 @@ public class LatexLabelReference extends PsiReferenceBase<LatexCommands> impleme
                         .withIcon(TexifyIcons.DOT_LABEL)
         ).toArray();
     }
-
-    @NotNull
-    @Override
-    public String getCanonicalText() {
-        return super.getCanonicalText();
-    }
 }

--- a/src/nl/rubensten/texifyidea/reference/LatexLabelReference.java
+++ b/src/nl/rubensten/texifyidea/reference/LatexLabelReference.java
@@ -8,6 +8,8 @@ import com.intellij.psi.PsiElementResolveResult;
 import com.intellij.psi.PsiPolyVariantReference;
 import com.intellij.psi.PsiReferenceBase;
 import com.intellij.psi.ResolveResult;
+import nl.rubensten.texifyidea.TexifyIcons;
+import nl.rubensten.texifyidea.completion.handlers.LatexReferenceInsertHandler;
 import nl.rubensten.texifyidea.psi.LatexCommands;
 import nl.rubensten.texifyidea.psi.LatexRequiredParam;
 import nl.rubensten.texifyidea.util.TexifyUtil;
@@ -52,8 +54,11 @@ public class LatexLabelReference extends PsiReferenceBase<LatexCommands> impleme
         Collection<LatexCommands> labels = TexifyUtil.findLabels(project);
 
         return labels.stream().map(
-                l -> LookupElementBuilder.create(l)
-                        .withTypeText(l.getContainingFile().getName())
+                l -> LookupElementBuilder.create(l.getRequiredParameters().get(0))
+                        .bold()
+                        .withInsertHandler(new LatexReferenceInsertHandler())
+                        .withTypeText(l.getContainingFile().getName(),true)
+                        .withIcon(TexifyIcons.DOT_LABEL)
         ).toArray();
     }
 

--- a/src/nl/rubensten/texifyidea/reference/LatexLabelReference.java
+++ b/src/nl/rubensten/texifyidea/reference/LatexLabelReference.java
@@ -1,0 +1,65 @@
+package nl.rubensten.texifyidea.reference;
+
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.PsiPolyVariantReference;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.ResolveResult;
+import nl.rubensten.texifyidea.psi.LatexCommands;
+import nl.rubensten.texifyidea.psi.LatexRequiredParam;
+import nl.rubensten.texifyidea.util.TexifyUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+/**
+ * @author Sten Wessel
+ */
+public class LatexLabelReference extends PsiReferenceBase<LatexCommands> implements PsiPolyVariantReference {
+    private String key;
+
+    public LatexLabelReference(@NotNull LatexCommands element, LatexRequiredParam param) {
+        super(element);
+        key = param.getText().substring(1, param.getText().length() - 1);
+
+        // Only show Ctrl+click underline under the reference name
+        setRangeInElement(new TextRange(param.getTextOffset() - element.getTextOffset() + 1, param.getTextOffset() - element.getTextOffset() + key.length() + 1));
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean b) {
+        Project project = myElement.getProject();
+        final Collection<LatexCommands> labels = TexifyUtil.findLabels(project, key);
+        return labels.stream().map(PsiElementResolveResult::new).toArray(ResolveResult[]::new);
+    }
+
+    @Nullable
+    @Override
+    public PsiElement resolve() {
+        ResolveResult[] resolveResults = multiResolve(false);
+        return resolveResults.length == 1 ? resolveResults[0].getElement() : null;
+    }
+
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+        Project project = myElement.getProject();
+        Collection<LatexCommands> labels = TexifyUtil.findLabels(project);
+
+        return labels.stream().map(
+                l -> LookupElementBuilder.create(l)
+                        .withTypeText(l.getContainingFile().getName())
+        ).toArray();
+    }
+
+    @NotNull
+    @Override
+    public String getCanonicalText() {
+        return super.getCanonicalText();
+    }
+}


### PR DESCRIPTION
Ctrl+click and Ctrl+B or whatever is related works on label references inside a `\ref{}` command.

Also changed the implementation of the reference completion, since this is provided by `PsiReference`.

Closes #46 