### PR TITLE
Fix for #82 (NPE Crash) and #80 (2017.2.1 update)

### DIFF
--- a/src/nl/rubensten/texifyidea/modules/LatexModuleType.java
+++ b/src/nl/rubensten/texifyidea/modules/LatexModuleType.java
@@ -40,10 +40,10 @@ public class LatexModuleType extends ModuleType<LatexModuleBuilder> {
         return "LaTeX";
     }
 
-    @Override
-    public Icon getBigIcon() {
-        return TexifyIcons.LATEX_MODULE;
-    }
+//    @Override
+//    public Icon getBigIcon() {
+//        return TexifyIcons.LATEX_MODULE;
+//    }
 
     @Override
     public Icon getNodeIcon(@Deprecated boolean isOpened) {

--- a/src/nl/rubensten/texifyidea/modules/LatexModuleType.java
+++ b/src/nl/rubensten/texifyidea/modules/LatexModuleType.java
@@ -40,11 +40,6 @@ public class LatexModuleType extends ModuleType<LatexModuleBuilder> {
         return "LaTeX";
     }
 
-//    @Override
-//    public Icon getBigIcon() {
-//        return TexifyIcons.LATEX_MODULE;
-//    }
-
     @Override
     public Icon getNodeIcon(@Deprecated boolean isOpened) {
         return TexifyIcons.LATEX_MODULE;

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -211,7 +211,7 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
         }
 
         String name = mainFile.getNameWithoutExtension();
-        return name == null || name.equals(getName());
+        return name != null && name.equals(getName());
     }
 
     @Nullable

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -206,7 +206,12 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
 
     @Override
     public boolean isGeneratedName() {
-        return mainFile.getNameWithoutExtension().equals(getName());
+        if (mainFile == null) {
+            return false;
+        }
+
+        String name = mainFile.getNameWithoutExtension();
+        return name == null || name.equals(getName());
     }
 
     @Nullable


### PR DESCRIPTION
# Changes
* Fixes Run Configuration related null pointer exceptions (null file).
* Removed `getBigIcon()` to align with the 2017.2.1 build of IntelliJ.