### PR TITLE
Reinstated file completion

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.java
@@ -50,7 +50,7 @@ public class LatexCompletionContributor extends CompletionContributor {
         // File names
         extend(
                 CompletionType.BASIC,
-                PlatformPatterns.psiElement(LatexTypes.NORMAL_TEXT)
+                PlatformPatterns.psiElement().inside(LatexNormalText.class)
                         .inside(LatexRequiredParam.class)
                         .with(new PatternCondition<PsiElement>(null) {
                             @Override


### PR DESCRIPTION
Problem was with the changed leaf parser element from the previous version. This used to be NORMAL_TEXT, but now is NORMAL_TEXT_WORD instead.

This closes #87.