### PR TITLE
Added quick navigation info for labels

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -224,5 +224,8 @@
 
         <!-- Inspections -->
         <spellchecker.support language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.LatexSpellcheckingStrategy"/>
+
+        <!-- Documentation -->
+        <lang.documentationProvider language="Latex" implementationClass="nl.rubensten.texifyidea.documentation.LatexDocumentationProvider"/>
   </extensions>
 </idea-plugin>

--- a/src/nl/rubensten/texifyidea/documentation/LatexDocumentationProvider.java
+++ b/src/nl/rubensten/texifyidea/documentation/LatexDocumentationProvider.java
@@ -22,7 +22,10 @@ public class LatexDocumentationProvider implements DocumentationProvider {
             if ("\\label".equals(cmd.getName())) {
                 String label = cmd.getRequiredParameters().get(0);
                 String file = cmd.getContainingFile().getName();
-                int line = StringUtil.offsetToLineNumber(cmd.getContainingFile().getText(), cmd.getTextOffset()) + 1;  // Because line numbers do start at 1
+                int line = 1 + StringUtil.offsetToLineNumber(
+                        cmd.getContainingFile().getText(),
+                        cmd.getTextOffset()
+                );  // Because line numbers do start at 1
                 return String.format("Go to declaration of label '%s' [%s:%d]", label, file, line);
             }
         }

--- a/src/nl/rubensten/texifyidea/documentation/LatexDocumentationProvider.java
+++ b/src/nl/rubensten/texifyidea/documentation/LatexDocumentationProvider.java
@@ -8,7 +8,6 @@ import nl.rubensten.texifyidea.psi.LatexCommands;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * @author Sten Wessel
@@ -20,7 +19,7 @@ public class LatexDocumentationProvider implements DocumentationProvider {
     public String getQuickNavigateInfo(PsiElement psiElement, PsiElement originalElement) {
         if (psiElement instanceof LatexCommands) {
             LatexCommands cmd = (LatexCommands)psiElement;
-            if (Objects.equals(cmd.getName(), "\\label")) {
+            if ("\\label".equals(cmd.getName())) {
                 String label = cmd.getRequiredParameters().get(0);
                 String file = cmd.getContainingFile().getName();
                 int line = StringUtil.offsetToLineNumber(cmd.getContainingFile().getText(), cmd.getTextOffset()) + 1;  // Because line numbers do start at 1

--- a/src/nl/rubensten/texifyidea/documentation/LatexDocumentationProvider.java
+++ b/src/nl/rubensten/texifyidea/documentation/LatexDocumentationProvider.java
@@ -1,0 +1,58 @@
+package nl.rubensten.texifyidea.documentation;
+
+import com.intellij.lang.documentation.DocumentationProvider;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiManager;
+import nl.rubensten.texifyidea.psi.LatexCommands;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Sten Wessel
+ */
+public class LatexDocumentationProvider implements DocumentationProvider {
+
+    @Nullable
+    @Override
+    public String getQuickNavigateInfo(PsiElement psiElement, PsiElement originalElement) {
+        if (psiElement instanceof LatexCommands) {
+            LatexCommands cmd = (LatexCommands)psiElement;
+            if (Objects.equals(cmd.getName(), "\\label")) {
+                String label = cmd.getRequiredParameters().get(0);
+                String file = cmd.getContainingFile().getName();
+                int line = StringUtil.offsetToLineNumber(cmd.getContainingFile().getText(), cmd.getTextOffset()) + 1;  // Because line numbers do start at 1
+                return String.format("Go to declaration of label '%s' [%s:%d]", label, file, line);
+            }
+        }
+
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getUrlFor(PsiElement psiElement, PsiElement originalElement) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String generateDoc(PsiElement psiElement, @Nullable PsiElement originalElement) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public PsiElement getDocumentationElementForLookupItem(PsiManager psiManager, Object o,
+                                                           PsiElement psiElement) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public PsiElement getDocumentationElementForLink(PsiManager psiManager, String s, PsiElement psiElement) {
+        return null;
+    }
+}


### PR DESCRIPTION
Adds proper formatting for goto label popup. Includes file name and line number where the label was declared.

![image](https://user-images.githubusercontent.com/11046840/29022616-5c9c6af0-7b6a-11e7-97a5-3617bf8be6e2.png)

Closes #91.