### PR TITLE
Fixed #89.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -5,8 +5,8 @@ import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionProvider;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -124,8 +124,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
             String tailText = getTailText(cmd);
             String typeText = getTypeText(cmd);
 
-            Document document = parameters.getEditor().getDocument();
-            int line = document.getLineNumber(cmd.getTextOffset()) + 1;
+            int line = 1 + StringUtil.offsetToLineNumber(cmd.getContainingFile().getText(), cmd.getTextOffset());
             typeText = typeText + " " + cmd.getContainingFile().getName() + ":" + line;
 
             result.addElement(LookupElementBuilder.create(cmd, cmdName.substring(1))


### PR DESCRIPTION
# Changes
* Fixed issue #89. This meant that command definitions in included files had the wrong line number shown as the plugin was using the currently opened editor to determine the line number. Now it solely relies on the included file. The IndexOutOfBoundsException occured because the included file is larger than the opened file causing a greater offset to be used than possible (hence index out of bounds).
* As a side effect, file names with line numbers have returned as type text with custom commands in the autocomplete.
![image](https://user-images.githubusercontent.com/17410729/29025525-75166a9c-7b77-11e7-9077-33bfa5002a1b.png)
