### PR TITLE
Non matching environment inspection

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -309,5 +309,8 @@
         <localInspection language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.UnresolvedReferenceInspection"
                          groupName="TeXiFy" displayName="Unresolved references"
                          enabledByDefault="true"/>
+        <localInspection language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.NonMatchingEnvironmentInspection"
+                         groupName="TeXiFy" displayName="Non matching environment commands"
+                         enabledByDefault="true"/>
   </extensions>
 </idea-plugin>

--- a/resources/inspectionDescriptions/NonMatchingEnvironment.html
+++ b/resources/inspectionDescriptions/NonMatchingEnvironment.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Each <tt>\begin</tt> and <tt>\end</tt> pair must have the same environment name.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/nl/rubensten/texifyidea/inspections/NonMatchingEnvironmentInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/NonMatchingEnvironmentInspection.kt
@@ -1,0 +1,100 @@
+package nl.rubensten.texifyidea.inspections
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import nl.rubensten.texifyidea.psi.LatexBeginCommand
+import nl.rubensten.texifyidea.psi.LatexEndCommand
+import nl.rubensten.texifyidea.util.*
+import kotlin.reflect.jvm.internal.impl.utils.SmartList
+
+/**
+ * @author Ruben Schellekens
+ */
+open class NonMatchingEnvironmentInspection : TexifyInspectionBase() {
+
+    override fun getDisplayName(): String {
+        return "Non matching environment commands"
+    }
+
+    override fun getShortName(): String {
+        return "NonMatchingEnvironment"
+    }
+
+    override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): List<ProblemDescriptor> {
+        val descriptors = SmartList<ProblemDescriptor>()
+
+        val begins = file.childrenOfType(LatexBeginCommand::class)
+        for (begin in begins) {
+            val end = begin.endCommand() ?: continue
+            val beginEnvironment = begin.environmentName() ?: continue
+            val endEnvironment = end.environmentName() ?: continue
+            if (beginEnvironment == endEnvironment) {
+                continue
+            }
+
+            // Add descriptor to begin.
+            descriptors.add(manager.createProblemDescriptor(
+                    begin,
+                    "Environment name does not match with the name in \\end.",
+                    MatchBeginFix(beginEnvironment),
+                    ProblemHighlightType.ERROR,
+                    isOntheFly
+            ))
+
+            // Add descriptor to end.
+            descriptors.add(manager.createProblemDescriptor(
+                    end,
+                    "Environment name does not match with the name in \\begin.",
+                    MatchEndFix(endEnvironment),
+                    ProblemHighlightType.ERROR,
+                    isOntheFly
+            ))
+        }
+
+        return descriptors
+    }
+
+    /**
+     * @author Ruben Schellekens
+     */
+    private open class MatchBeginFix(val environmentName: String) : LocalQuickFix {
+
+        override fun getFamilyName(): String {
+            return "Change \\end environment to '$environmentName'"
+        }
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val command = descriptor.psiElement as LatexBeginCommand
+            val file = command.containingFile
+            val document = file.document() ?: return
+            val end = command.endCommand() ?: return
+            val environment = command.environmentName()
+
+            document.replaceString(end.textOffset, end.endOffset(), "\\end{$environment}")
+        }
+    }
+
+    /**
+     * @author Ruben Schellekens
+     */
+    private open class MatchEndFix(val environmentName: String) : LocalQuickFix {
+
+        override fun getFamilyName(): String {
+            return "Change \\begin environment to '$environmentName'"
+        }
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val command = descriptor.psiElement as LatexEndCommand
+            val file = command.containingFile
+            val document = file.document() ?: return
+            val begin = command.beginCommand() ?: return
+            val environment = command.environmentName()
+
+            document.replaceString(begin.textOffset, begin.endOffset(), "\\begin{$environment}")
+        }
+    }
+}

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -51,6 +51,44 @@ fun PsiElement.previousSiblingIgnoreWhitespace() = LatexPsiUtil.getPreviousSibli
 fun PsiElement.nextSiblingIgnoreWhitespace() = LatexPsiUtil.getNextSiblingIgnoreWhitespace(this)
 
 /**
+ * Finds the next sibling of the element that has the given type.
+ *
+ * @return The first following sibling of the given type, or `null` when the sibling couldn't be found.
+ */
+fun <T : PsiElement> PsiElement.nextSiblingOfType(clazz: KClass<T>): T? {
+    var sibling: PsiElement? = this
+    while (sibling != null) {
+        if (clazz.java.isAssignableFrom(sibling::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return sibling as T
+        }
+
+        sibling = sibling.nextSibling
+    }
+
+    return null
+}
+
+/**
+ * Finds the previous sibling of the element that has the given type.
+ *
+ * @return The first previous sibling of the given type, or `null` when the sibling couldn't be found.
+ */
+fun <T : PsiElement> PsiElement.previousSiblingOfType(clazz: KClass<T>): T? {
+    var sibling: PsiElement? = this
+    while (sibling != null) {
+        if (clazz.java.isAssignableFrom(sibling::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return sibling as T
+        }
+
+        sibling = sibling.prevSibling
+    }
+
+    return null
+}
+
+/**
  * @see LatexPsiUtil.getAllChildren
  */
 fun PsiElement.allChildren(): List<PsiElement> = LatexPsiUtil.getAllChildren(this)
@@ -173,7 +211,7 @@ fun LatexBeginCommand.environmentName(): String? = beginOrEndEnvironmentName(thi
 /**
  * Finds the [LatexEndCommand] that matches the begin command.
  */
-fun LatexBeginCommand.endCommand(): LatexEndCommand? = nextSiblingIgnoreWhitespace() as? LatexEndCommand
+fun LatexBeginCommand.endCommand(): LatexEndCommand? = nextSiblingOfType(LatexEndCommand::class)
 
 /**
  * Get the environment name of the end command.
@@ -183,4 +221,4 @@ fun LatexEndCommand.environmentName(): String? = beginOrEndEnvironmentName(this)
 /**
  * Finds the [LatexBeginCommand] that matches the end command.
  */
-fun LatexEndCommand.beginCommand(): LatexBeginCommand? = previousSiblingIgnoreWhitespace() as? LatexBeginCommand
+fun LatexEndCommand.beginCommand(): LatexBeginCommand? = previousSiblingOfType(LatexBeginCommand::class)

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -6,10 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import nl.rubensten.texifyidea.index.LatexCommandsIndex
-import nl.rubensten.texifyidea.psi.LatexBeginCommand
-import nl.rubensten.texifyidea.psi.LatexCommands
-import nl.rubensten.texifyidea.psi.LatexMathContent
-import nl.rubensten.texifyidea.psi.LatexPsiUtil
+import nl.rubensten.texifyidea.psi.*
 import kotlin.reflect.KClass
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -149,6 +146,41 @@ fun LatexCommands.forcedFirstRequiredParameterAsCommand(): LatexCommands = Texif
 fun LatexCommands.isKnown(): Boolean = TexifyUtil.isCommandKnown(this)
 
 /**
+ * Get the environment name of a begin/end command.
+ *
+ * @param element
+ *              Either a [LatexBeginCommand] or a [LatexEndCommand]
+ */
+private fun beginOrEndEnvironmentName(element: PsiElement): String? {
+    val children = element.childrenOfType(LatexNormalText::class)
+    if (children.isEmpty()) {
+        return null
+    }
+
+    return children.first().text
+}
+
+/**
  * @see TexifyUtil.isEntryPoint
  */
 fun LatexBeginCommand.isEntryPoint(): Boolean = TexifyUtil.isEntryPoint(this)
+
+/**
+ * Get the environment name of the begin command.
+ */
+fun LatexBeginCommand.environmentName(): String? = beginOrEndEnvironmentName(this)
+
+/**
+ * Finds the [LatexEndCommand] that matches the begin command.
+ */
+fun LatexBeginCommand.endCommand(): LatexEndCommand? = nextSiblingIgnoreWhitespace() as? LatexEndCommand
+
+/**
+ * Get the environment name of the end command.
+ */
+fun LatexEndCommand.environmentName(): String? = beginOrEndEnvironmentName(this)
+
+/**
+ * Finds the [LatexBeginCommand] that matches the end command.
+ */
+fun LatexEndCommand.beginCommand(): LatexBeginCommand? = previousSiblingIgnoreWhitespace() as? LatexBeginCommand


### PR DESCRIPTION
# Changes
- Adds an inspection that checks for matching environment names.
- Provides 2 quick fixes: change the `\end` name, or the `\begin` name.

# Pictures
![image](https://user-images.githubusercontent.com/17410729/29591578-9eec206c-879f-11e7-9e13-f2e7febec1d0.png)

![image](https://user-images.githubusercontent.com/17410729/29591585-a68c5058-879f-11e7-90ea-f7e1d9a4bbd2.png)

![image](https://user-images.githubusercontent.com/17410729/29591591-adce19fa-879f-11e7-8558-c3552d6440e3.png)
