### PR TITLE
Added auto insertion for \leftX \rightX.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/handlers/LatexMathInsertHandler.java
+++ b/src/nl/rubensten/texifyidea/completion/handlers/LatexMathInsertHandler.java
@@ -13,5 +13,6 @@ public class LatexMathInsertHandler implements InsertHandler<LookupElement> {
     public void handleInsert(InsertionContext context, LookupElement item) {
         new LatexCommandArgumentInsertHandler().handleInsert(context, item);
         new LatexCommandPackageIncludeHandler().handleInsert(context, item);
+        new RightInsertHandler().handleInsert(context, item);
     }
 }

--- a/src/nl/rubensten/texifyidea/completion/handlers/RightInsertHandler.kt
+++ b/src/nl/rubensten/texifyidea/completion/handlers/RightInsertHandler.kt
@@ -1,0 +1,45 @@
+package nl.rubensten.texifyidea.completion.handlers
+
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.openapi.editor.Editor
+import nl.rubensten.texifyidea.lang.LatexMathCommand
+import nl.rubensten.texifyidea.util.mapOfVarargs
+
+/**
+ * @author Ruben Schellekens
+ */
+open class RightInsertHandler : InsertHandler<LookupElement> {
+
+    companion object {
+
+        /**
+         * Maps `\left` => `\right`.
+         */
+        val OPPOSITES = mapOfVarargs(
+                "(", ")",
+                "[", "]",
+                "\\{", "\\}",
+                "<", ">",
+                "|", "|",
+                "\\|", "\\|"
+        )
+    }
+
+    override fun handleInsert(context: InsertionContext?, element: LookupElement?) {
+        val editor = context?.editor ?: return
+        val command = element?.`object` as? LatexMathCommand ?: return
+        val name = command.command
+
+        if (name.startsWith("left")) {
+            insertRight(name, editor)
+        }
+    }
+
+    private fun insertRight(commandName: String, editor: Editor) {
+        val char = commandName.substring(4)
+        val opposite = OPPOSITES[char] ?: return
+        editor.document.insertString(editor.caretModel.offset, "\\right$opposite")
+    }
+}

--- a/src/nl/rubensten/texifyidea/lang/LatexMathCommand.java
+++ b/src/nl/rubensten/texifyidea/lang/LatexMathCommand.java
@@ -144,6 +144,22 @@ public enum LatexMathCommand implements LatexCommand {
     BOXED_DOT("boxdot", AMSSYMB, "⊡", false),
 
     /*
+     *  Left/Right
+     */
+    LEFT_PARENTH("left(", "(", false),
+    RIGHT_PARENTH("right)", ")", false),
+    LEFT_BRACKET("left[", "[", false),
+    RIGHT_BRACKET("right]", "]", false),
+    LEFT_BRACE("left\\{", "{", false),
+    RIGHT_BRACE("right\\}", "}", false),
+    LEFT_ANGULAR("left<", "<", false),
+    RIGHT_ANGULAR("right>", ">", false),
+    LEFT_PIPE("left|", "|", false),
+    RIGHT_PIPE("right|", "|", false),
+    LEFT_DOUBLE_PIPE("left\\|", "||", false),
+    RIGHT_DOUBLE_PIPE("right\\|", "||", false),
+
+    /*
         Generic commands
      */
     MATHBF("mathbf", required("text")),

--- a/src/nl/rubensten/texifyidea/util/CollectionUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/CollectionUtil.kt
@@ -1,6 +1,8 @@
 package nl.rubensten.texifyidea.util
 
 import java.util.*
+import java.util.stream.Collectors
+import java.util.stream.Stream
 
 /**
  * Puts all the elements of an array into a mutable map.
@@ -55,3 +57,35 @@ fun <T> mapOfVarargs(vararg args: T): Map<T, T> = mutableMapOfArray(args)
  * Gets a random element from the list using the given random object.
  */
 fun <T> List<T>.randomElement(random: Random): T = this[random.nextInt(this.size)]
+
+/**
+ * Looks up keys in the map that has the given `value`.
+ *
+ * @return All keys with the given value.
+ */
+fun <K, V> Map<K, V>.findKeys(value: V): Set<K> {
+    return entries.stream()
+            .filter { (_, v) -> v == value }
+            .map { it.key }
+            .set()
+}
+
+/**
+ * Collects stream to [List].
+ */
+fun <T> Stream<T>.list(): List<T> = this.mutableList()
+
+/**
+ * Collects stream to [MutableList].
+ */
+fun <T> Stream<T>.mutableList(): MutableList<T> = this.collect(Collectors.toList())
+
+/**
+ * Collects stream to [Set].
+ */
+fun <T> Stream<T>.set(): Set<T> = this.mutableSet()
+
+/**
+ * Collects stream to [MutableSet]
+ */
+fun <T> Stream<T>.mutableSet(): MutableSet<T> = this.collect(Collectors.toSet())


### PR DESCRIPTION
# Changes
- Added `\leftX`/`\rightX` to autocomplete for `() [] \{\} || \|\| <>`
- Automatically inserts the `\rightX` variant when `\leftX` is selected from the autocomplete.