### PR TITLE
Auto insertion of `{}` when having multiple characters in super/subscript in math mode.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -231,6 +231,7 @@
         <lookup.charFilter implementation="nl.rubensten.texifyidea.completion.LatexCharFilter" id="latex"/>
         <enterHandlerDelegate implementation="nl.rubensten.texifyidea.editor.InsertEnumerationItem" />
         <typedHandler implementation="nl.rubensten.texifyidea.editor.ShiftTracker" />
+        <typedHandler implementation="nl.rubensten.texifyidea.editor.UpDownAutoBracket" />
 
         <!-- Line markers -->
         <codeInsight.lineMarkerProvider language="Latex" implementationClass="nl.rubensten.texifyidea.gutter.LatexLineMarkerProvider"/>

--- a/src/nl/rubensten/texifyidea/completion/handlers/RightInsertHandler.kt
+++ b/src/nl/rubensten/texifyidea/completion/handlers/RightInsertHandler.kt
@@ -40,6 +40,7 @@ open class RightInsertHandler : InsertHandler<LookupElement> {
     private fun insertRight(commandName: String, editor: Editor) {
         val char = commandName.substring(4)
         val opposite = OPPOSITES[char] ?: return
-        editor.document.insertString(editor.caretModel.offset, "\\right$opposite")
+        editor.document.insertString(editor.caretModel.offset, "  \\right$opposite")
+        editor.caretModel.moveToOffset(editor.caretModel.offset + 1)
     }
 }

--- a/src/nl/rubensten/texifyidea/editor/InsertEnumerationItem.kt
+++ b/src/nl/rubensten/texifyidea/editor/InsertEnumerationItem.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.util.Ref
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import nl.rubensten.texifyidea.file.LatexFileType
 import nl.rubensten.texifyidea.psi.LatexCommands
 import nl.rubensten.texifyidea.psi.LatexEnvironment
 import nl.rubensten.texifyidea.util.*
@@ -27,8 +28,11 @@ class InsertEnumerationItem : EnterHandlerDelegate {
 
     override fun postProcessEnter(file: PsiFile, editor: Editor, context: DataContext): EnterHandlerDelegate.Result {
         ShiftTracker.setup(editor.contentComponent)
-        val caret = editor.caretModel
+        if (file.fileType != LatexFileType.INSTANCE) {
+            return Result.Continue
+        }
 
+        val caret = editor.caretModel
         val element = file.findElementAt(caret.offset)
         if (hasValidContext(element)) {
             editor.insertAndMove(caret.offset, getInsertionString(element!!))

--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -1,0 +1,123 @@
+package nl.rubensten.texifyidea.editor
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import nl.rubensten.texifyidea.file.LatexFileType
+import nl.rubensten.texifyidea.psi.LatexMathContent
+import nl.rubensten.texifyidea.psi.LatexMathEnvironment
+import nl.rubensten.texifyidea.psi.LatexNoMathContent
+import nl.rubensten.texifyidea.psi.LatexNormalText
+import nl.rubensten.texifyidea.util.firstChildOfType
+import nl.rubensten.texifyidea.util.hasParent
+import nl.rubensten.texifyidea.util.lastChildOfType
+import nl.rubensten.texifyidea.util.previousSiblingIgnoreWhitespace
+import java.util.regex.Pattern
+
+/**
+ * @author Ruben Schellekens
+ */
+open class UpDownAutoBracket : TypedHandlerDelegate() {
+
+    companion object {
+
+        /**
+         * Symbols that denote wheter a {} block has to be inserted when having more than 1 character.
+         */
+        val INSERT_SYMBOLS = setOf("_", "^")
+
+        /**
+         * Matches the suffix that denotes that braces may be inserted.
+         */
+        val INSERT_REQUIREMENT = Pattern.compile("^[a-zA-Z0-9]$")!!
+    }
+
+    override fun charTyped(c: Char, project: Project?, editor: Editor, file: PsiFile): Result {
+        if (file.fileType != LatexFileType.INSTANCE) {
+            return Result.CONTINUE
+        }
+
+        // Find selected element.
+        val caret = editor.caretModel
+        val element = file.findElementAt(caret.offset - 1) ?: return Result.CONTINUE
+
+        // Insert squiggly brackets.
+        if (element is LatexNormalText) {
+            handleNormalText(element, editor)
+        }
+        else {
+            val normalText = findNormalText(element)
+            if (normalText != null) {
+                handleNormalText(normalText, editor)
+            }
+        }
+
+        return Result.CONTINUE
+    }
+
+    private fun findNormalText(element: PsiElement): LatexNormalText? {
+        return exit@ when (element) {
+            is PsiWhiteSpace -> {
+                // Whenever the whitespace is the end of a math environment.
+                val sibling = element.previousSiblingIgnoreWhitespace()
+                if (sibling != null) {
+                    if (sibling is LatexMathContent) {
+                        return@exit sibling.lastChildOfType(LatexNoMathContent::class)
+                                ?.firstChildOfType(LatexNormalText::class)
+                    }
+                    else {
+                        return@exit sibling.firstChildOfType(LatexNormalText::class)
+                    }
+                }
+
+                return@exit null
+            }
+            is LeafPsiElement -> {
+                // Whenever a character is inserted just before the close brace of a group/inline math end.
+                val content = element.prevSibling?: return@exit null
+                return@exit content.firstChildOfType(LatexNormalText::class)
+            }
+            else -> null
+        }
+    }
+
+    private fun handleNormalText(normalText: LatexNormalText, editor: Editor) {
+        // Check if in math environment.
+        if (!normalText.hasParent(LatexMathEnvironment::class)) {
+            return
+        }
+
+        val text = normalText.text
+        val offset = normalText.textOffset
+        val caret = editor.caretModel
+        val relative = caret.offset - normalText.textOffset
+
+        if (relative < 3 || text.length < relative - 1) {
+            return
+        }
+
+        // Only insert when a valid symbol has been typed.
+        val afterSymbol = text.substring(relative - 2, relative - 1)
+        if (!INSERT_REQUIREMENT.matcher(afterSymbol).matches()) {
+            return
+        }
+
+        // Check if the inserted symbol is eligible for brace insertion.
+        val subSupSymbol = text.substring(relative - 3, relative - 2)
+        if (!INSERT_SYMBOLS.contains(subSupSymbol)) {
+            return
+        }
+
+        insert(offset + relative - 3, editor)
+    }
+
+    private fun insert(symbolOffset: Int, editor: Editor) {
+        val document = editor.document
+        document.insertString(symbolOffset + 1, "{")
+        document.insertString(symbolOffset + 4, "}")
+    }
+}

--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -31,9 +31,9 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
         val INSERT_SYMBOLS = setOf("_", "^")
 
         /**
-         * Matches the suffix that denotes that braces may be inserted.
+         * Matches the suffix that denotes that braces may not be inserted.
          */
-        val INSERT_REQUIREMENT = Pattern.compile("^[a-zA-Z0-9]$")!!
+        val INSERT_FORBIDDEN = Pattern.compile("^\\s+$")!!
     }
 
     override fun charTyped(c: Char, project: Project?, editor: Editor, file: PsiFile): Result {
@@ -47,12 +47,12 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
 
         // Insert squiggly brackets.
         if (element is LatexNormalText) {
-            handleNormalText(element, editor)
+            handleNormalText(element, editor, c)
         }
         else {
             val normalText = findNormalText(element)
             if (normalText != null) {
-                handleNormalText(normalText, editor)
+                handleNormalText(normalText, editor, c)
             }
         }
 
@@ -78,14 +78,14 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
             }
             is LeafPsiElement -> {
                 // Whenever a character is inserted just before the close brace of a group/inline math end.
-                val content = element.prevSibling?: return@exit null
+                val content = element.prevSibling ?: return@exit null
                 return@exit content.firstChildOfType(LatexNormalText::class)
             }
             else -> null
         }
     }
 
-    private fun handleNormalText(normalText: LatexNormalText, editor: Editor) {
+    private fun handleNormalText(normalText: LatexNormalText, editor: Editor, char: Char) {
         // Check if in math environment.
         if (!normalText.hasParent(LatexMathEnvironment::class)) {
             return
@@ -101,8 +101,8 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
         }
 
         // Only insert when a valid symbol has been typed.
-        val afterSymbol = text.substring(relative - 2, relative - 1)
-        if (!INSERT_REQUIREMENT.matcher(afterSymbol).matches()) {
+        val afterSymbol = char.toString()
+        if (INSERT_FORBIDDEN.matcher(afterSymbol).matches()) {
             return
         }
 

--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -35,7 +35,7 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
         /**
          * Matches the suffix that denotes that braces may not be inserted.
          */
-        val INSERT_FORBIDDEN = Pattern.compile("^[\\s^_,.;%]$")!!
+        val INSERT_FORBIDDEN = Pattern.compile("^[\\s^_,.;%:$]$")!!
     }
 
     override fun charTyped(c: Char, project: Project?, editor: Editor, file: PsiFile): Result {

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -24,6 +24,30 @@ fun PsiElement.endOffset(): Int = textOffset + textLength
 fun <T : PsiElement> PsiElement.childrenOfType(clazz: KClass<T>): Collection<T> = PsiTreeUtil.findChildrenOfType(this, clazz.java)
 
 /**
+ * See method name.
+ */
+fun <T : PsiElement> PsiElement.firstChildOfType(clazz: KClass<T>): T? {
+    val children = childrenOfType(clazz)
+    if (children.isEmpty()) {
+        return null
+    }
+
+    return children.first()
+}
+
+/**
+ * See method name.
+ */
+fun <T : PsiElement> PsiElement.lastChildOfType(clazz: KClass<T>): T? {
+    val children = childrenOfType(clazz)
+    if (children.isEmpty()) {
+        return null
+    }
+
+    return children.last()
+}
+
+/**
  * @see [PsiTreeUtil.getParentOfType]
  */
 fun <T : PsiElement> PsiElement.parentOfType(clazz: KClass<T>): T? = PsiTreeUtil.getParentOfType(this, clazz.java)

--- a/src/nl/rubensten/texifyidea/util/StringUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/StringUtil.kt
@@ -27,6 +27,17 @@ fun String.camelCase(): String {
  */
 fun String.repeat(count: Int): String = TexifyUtil.fill(this, count)
 
-fun main(args: Array<String>) {
+/**
+ * Takes the substring, but with inverted index, i.e. the index of the first character is `length`, the last index is `0`.
+ */
+fun String.substringEnd(startIndex: Int): String = substring(0, length - startIndex)
 
-}
+/**
+ * Takes the substring, but with inverted index, i.e. the index of the first character is `length`, the last index is `0`.
+ */
+fun String.substringEnd(startIndex: Int, endIndex: Int): String = substring(length - endIndex, length - startIndex)
+
+/**
+ * Takes the substring, but with inverted index, i.e. the index of the first character is `length`, the last index is `0`.
+ */
+fun String.substringEnd(range: IntRange): String = substringEnd(range.start, range.endInclusive + 1)


### PR DESCRIPTION
# Changes
- Whenever you write multiple characters in a subscript (e.g. `a_ij`), braces get inserted automatically (e.g. `a_{ij}`)
- When inserting `left` and `righ`, two extra spaces are inserted (i.e. `\left( ^ \right)` where `^` is the cursor).
