### PR TITLE
File autocomplete of \include omits extension - Fixes #118.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.kt
+++ b/src/nl/rubensten/texifyidea/completion/LatexCompletionContributor.kt
@@ -74,9 +74,7 @@ open class LatexCompletionContributor : CompletionContributor() {
                         .inside(LatexRequiredParam::class.java)
                         .with(object : PatternCondition<PsiElement>(null) {
                             override fun accepts(psiElement: PsiElement, processingContext: ProcessingContext): Boolean {
-                                val command = LatexPsiUtil.getParentOfType(
-                                        psiElement, LatexCommands::class.java
-                                ) ?: return false
+                                val command = LatexPsiUtil.getParentOfType(psiElement, LatexCommands::class.java) ?: return false
 
                                 val name = command.commandToken.text
                                 val cmd = LatexNoMathCommand.get(name.substring(1)).orElse(null) ?: return false

--- a/src/nl/rubensten/texifyidea/completion/LatexFileProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexFileProvider.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.PlatformIcons;
 import com.intellij.util.ProcessingContext;
 import nl.rubensten.texifyidea.TexifyIcons;
+import nl.rubensten.texifyidea.completion.handlers.CompositeHandler;
+import nl.rubensten.texifyidea.completion.handlers.FileNameInsertionHandler;
 import nl.rubensten.texifyidea.completion.handlers.LatexReferenceInsertHandler;
 import nl.rubensten.texifyidea.util.Kindness;
 import org.jetbrains.annotations.NotNull;
@@ -81,12 +83,15 @@ public class LatexFileProvider extends CompletionProvider<CompletionParameters> 
             result.addElement(
                     LookupElementBuilder.create(noBack(autocompleteText) + file.getName())
                             .withPresentableText(fileName)
-                            .withInsertHandler(new LatexReferenceInsertHandler())
+                            .withInsertHandler(new CompositeHandler<>(
+                                    new LatexReferenceInsertHandler(),
+                                    new FileNameInsertionHandler()
+                            ))
                             .withIcon(icon)
             );
         }
 
-        result.addLookupAdvertisement(Kindness.INSTANCE.getKindWords());
+        result.addLookupAdvertisement(Kindness.getKindWords());
     }
 
     private String noBack(String stuff) {

--- a/src/nl/rubensten/texifyidea/completion/handlers/CompositeHandler.kt
+++ b/src/nl/rubensten/texifyidea/completion/handlers/CompositeHandler.kt
@@ -1,0 +1,15 @@
+package nl.rubensten.texifyidea.completion.handlers
+
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+
+/**
+ * @author Ruben Schellekens
+ */
+open class CompositeHandler<T : LookupElement>(vararg val handlers: InsertHandler<T>) : InsertHandler<T> {
+
+    override fun handleInsert(context: InsertionContext?, lookupElement: T) {
+        handlers.forEach { it.handleInsert(context, lookupElement) }
+    }
+}

--- a/src/nl/rubensten/texifyidea/completion/handlers/FileNameInsertionHandler.kt
+++ b/src/nl/rubensten/texifyidea/completion/handlers/FileNameInsertionHandler.kt
@@ -1,0 +1,32 @@
+package nl.rubensten.texifyidea.completion.handlers
+
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.document
+import nl.rubensten.texifyidea.util.endOffset
+import nl.rubensten.texifyidea.util.parentOfType
+import nl.rubensten.texifyidea.util.removeFileExtension
+
+/**
+ * @author Ruben Schellekens
+ */
+open class FileNameInsertionHandler : InsertHandler<LookupElement> {
+
+    override fun handleInsert(context: InsertionContext?, element: LookupElement?) {
+        val text = element?.`object` ?: return
+        val file = context?.file ?: return
+        val document = file.document() ?: return
+        val offset = context.startOffset
+        val normalTextWord = file.findElementAt(offset) ?: return
+        val command = normalTextWord.parentOfType(LatexCommands::class) ?: return
+
+        if (command.name != "\\include") {
+            return
+        }
+
+        val extensionless = text.toString().removeFileExtension()
+        document.replaceString(command.textOffset, command.endOffset(), "\\include{$extensionless}")
+    }
+}

--- a/src/nl/rubensten/texifyidea/util/FileUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/FileUtil.kt
@@ -4,8 +4,25 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import java.util.regex.Pattern
+
+/**
+ * @author Ruben Schellekens
+ */
+object FileUtil {
+
+    /**
+     * Matches the extension of a file name, including the dot.
+     */
+    val FILE_EXTENSION = Pattern.compile("\\.[^.]+$")
+}
 
 /**
  * Looks up the PsiFile that corresponds to the Virtual File.
  */
 fun VirtualFile.psiFile(project: Project): PsiFile? = PsiManager.getInstance(project).findFile(this)
+
+/**
+ * Removes the extension from a given file name.
+ */
+fun String.removeFileExtension() = FileUtil.FILE_EXTENSION.matcher(this).replaceAll("")


### PR DESCRIPTION
# Changes
- When you insert `\include` using the autocomplete and select a file from the list, the extension gets omitted. (#118)