### PR TITLE
Added breadcrumbs for environments and commands.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -217,6 +217,9 @@
         <!-- Structure view -->
         <lang.psiStructureViewFactory language="Latex" implementationClass="nl.rubensten.texifyidea.structure.LatexStructureViewFactory"/>
 
+        <!-- Breadcrumbs -->
+        <breadcrumbsInfoProvider implementation="nl.rubensten.texifyidea.structure.LatexBreadcrumbsInfo"/>
+
         <!-- Project view -->
         <projectViewNodeDecorator implementation="nl.rubensten.texifyidea.project.TeXiFyProjectViewNodeDecorator"/>
 

--- a/src/nl/rubensten/texifyidea/structure/LatexBreadcrumbsInfo.kt
+++ b/src/nl/rubensten/texifyidea/structure/LatexBreadcrumbsInfo.kt
@@ -1,0 +1,28 @@
+package nl.rubensten.texifyidea.structure
+
+import com.intellij.psi.PsiElement
+import com.intellij.xml.breadcrumbs.BreadcrumbsInfoProvider
+import nl.rubensten.texifyidea.LatexLanguage
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.psi.LatexEnvironment
+import nl.rubensten.texifyidea.util.name
+
+/**
+ * @author Ruben Schellekens
+ */
+open class LatexBreadcrumbsInfo : BreadcrumbsInfoProvider() {
+
+    override fun getLanguages() = arrayOf(LatexLanguage.INSTANCE)
+
+    override fun getElementInfo(element: PsiElement) = when (element) {
+        is LatexEnvironment -> element.name()?.text
+        is LatexCommands -> element.commandToken.text
+        else -> ""
+    } ?: ""
+
+    override fun acceptElement(element: PsiElement) = when (element) {
+        is LatexEnvironment -> true
+        is LatexCommands -> true
+        else -> false
+    }
+}

--- a/src/nl/rubensten/texifyidea/structure/LatexBreadcrumbsInfo.kt
+++ b/src/nl/rubensten/texifyidea/structure/LatexBreadcrumbsInfo.kt
@@ -1,7 +1,7 @@
 package nl.rubensten.texifyidea.structure
 
 import com.intellij.psi.PsiElement
-import com.intellij.xml.breadcrumbs.BreadcrumbsInfoProvider
+import com.intellij.ui.breadcrumbs.BreadcrumbsProvider
 import nl.rubensten.texifyidea.LatexLanguage
 import nl.rubensten.texifyidea.psi.LatexCommands
 import nl.rubensten.texifyidea.psi.LatexEnvironment
@@ -10,7 +10,7 @@ import nl.rubensten.texifyidea.util.name
 /**
  * @author Ruben Schellekens
  */
-open class LatexBreadcrumbsInfo : BreadcrumbsInfoProvider() {
+open class LatexBreadcrumbsInfo : BreadcrumbsProvider {
 
     override fun getLanguages() = arrayOf(LatexLanguage.INSTANCE)
 


### PR DESCRIPTION
# Changes
- Added breadcrumbs for LatexCommands and LatexEnvironment.
- It does make use of the deprecated ~~`BreadcrumbsInfoProvider`~~. Couldn't find a better way to do it. Just to keep in mind for later updates.

# Pictures
![image](https://user-images.githubusercontent.com/17410729/30002754-87b523ba-90b1-11e7-904c-b717e0ae947a.png)
