### PR TITLE
Added DeclareMathOperator support.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -49,7 +49,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
                 break;
             case MATH:
                 addMathCommands(result);
-                addCustomCommands(parameters, result);
+                addCustomCommands(parameters, result, LatexMode.MATH);
                 break;
             case ENVIRONMENT_NAME:
                 addEnvironments(result);
@@ -106,6 +106,11 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
     }
 
     private void addCustomCommands(CompletionParameters parameters, CompletionResultSet result) {
+        addCustomCommands(parameters, result, null);
+    }
+
+    private void addCustomCommands(CompletionParameters parameters, CompletionResultSet result,
+                                   @Nullable LatexMode mode) {
         Project project = parameters.getEditor().getProject();
         if (project == null) {
             return;
@@ -123,6 +128,10 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         for (LatexCommands cmd : cmds) {
             if (!isDefinition(cmd)) {
                 continue;
+            }
+
+            if (mode != LatexMode.MATH && "\\DeclareMathOperator".equals(cmd.getName())) {
+               continue;
             }
 
             String cmdName = getCommandName(cmd);
@@ -195,11 +204,11 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
 
     @Nullable
     private String getCommandName(@NotNull LatexCommands commands) {
-        if ("\\newcommand".equals(commands.getCommandToken().getText())) {
-            return getNewCommandName(commands);
+        switch (commands.getName()) {
+            case "\\DeclareMathOperator":
+            case "\\newcommand": return getNewCommandName(commands);
+            default: return getDefinitionName(commands);
         }
-
-        return getDefinitionName(commands);
     }
 
     @Nullable
@@ -226,7 +235,8 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         return commands != null && (
                 "\\newcommand".equals(commands.getCommandToken().getText()) ||
                         "\\let".equals(commands.getCommandToken().getText()) ||
-                        "\\def".equals(commands.getCommandToken().getText())
+                        "\\def".equals(commands.getCommandToken().getText()) ||
+                        "\\DeclareMathOperator".equals(commands.getCommandToken().getText())
         );
     }
 }

--- a/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.java
+++ b/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.java
@@ -45,6 +45,7 @@ public enum LatexNoMathCommand implements LatexCommand {
     CONTENTSLINE("contentsline", required("type"), requiredText("text"), required("page")),
     CONTENTSNAME("contentsname", required("name")),
     DATE("date", requiredText("text")),
+    DECLARE_MATH_OPERATOR("DeclareMathOperator", required("command"), requiredText("operator")),
     DEF("def"),
     DOCUMENTCLASS("documentclass", optional("options"), required("class")),
     DOTFILL("dotfill"),

--- a/src/nl/rubensten/texifyidea/structure/LatexNewCommandPresentation.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexNewCommandPresentation.java
@@ -17,10 +17,6 @@ public class LatexNewCommandPresentation implements ItemPresentation {
     private final String locationString;
 
     public LatexNewCommandPresentation(LatexCommands newCommand) {
-        if (!newCommand.getCommandToken().getText().equals("\\newcommand")) {
-            throw new IllegalArgumentException("command is no \\newcommand-command");
-        }
-
         // Fetch parameter amount.
         List<String> optional = newCommand.getOptionalParameters();
         int params = -1;

--- a/src/nl/rubensten/texifyidea/structure/LatexPresentationFactory.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexPresentationFactory.java
@@ -26,6 +26,7 @@ public class LatexPresentationFactory {
             case "\\subparagraph":
                 return new LatexSubParagraphPresentation(commands);
             case "\\newcommand":
+            case "\\DeclareMathOperator":
                 return new LatexNewCommandPresentation(commands);
             case "\\label":
                 return new LatexLabelPresentation(commands);

--- a/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
@@ -172,6 +172,7 @@ public class LatexStructureViewElement implements StructureViewTreeElement, Sort
 
         // Add command definitions.
         addFromCommand(treeElements, commands, "\\newcommand");
+        addFromCommand(treeElements, commands, "\\DeclareMathOperator");
         addFromCommand(treeElements, commands, "\\let");
         addFromCommand(treeElements, commands, "\\def");
 

--- a/src/nl/rubensten/texifyidea/structure/filter/LatexNewCommandFilter.java
+++ b/src/nl/rubensten/texifyidea/structure/filter/LatexNewCommandFilter.java
@@ -23,6 +23,7 @@ public class LatexNewCommandFilter implements Filter {
 
         LatexStructureViewCommandElement element = (LatexStructureViewCommandElement)treeElement;
         return !(element.getCommandName().equals("\\newcommand") ||
+                element.getCommandName().equals("\\DeclareMathOperator") ||
                 element.getPresentation() instanceof LatexOtherCommandPresentation);
     }
 


### PR DESCRIPTION
# Changes
- Operators defined with `\DeclareMathOperator` do now appear in the autocomplete in math mode.
- `\DeclareMathOperator` added to autocomplete list.
- Operators declared as `\DeclareMathOperator` appear in the structure view under newcommands.