### PR TITLE
Jump to end of label when inserting with the MissingLabel inspection.

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/MissingLabelInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/MissingLabelInspection.kt
@@ -91,7 +91,13 @@ open class MissingLabelInspection : TexifyInspectionBase() {
             val createdLabel = appendCounter(createdLabelBase, allLabels)
 
             // Insert label.
-            document.insertString(command.endOffset(), "\\label{$createdLabel}")
+            val labelText = "\\label{$createdLabel}"
+            document.insertString(command.endOffset(), labelText)
+
+            // Adjust caret offset.
+            val editor = file.openedEditor() ?: return
+            val caret = editor.caretModel
+            caret.moveToOffset(command.endOffset() + labelText.length)
         }
 
         /**

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -1,6 +1,7 @@
 package nl.rubensten.texifyidea.util
 
 import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -249,6 +250,11 @@ fun PsiFile.labelsInFileSet(): Set<String> = TexifyUtil.findLabelsInFileSet(this
  * @see TexifyUtil.getReferencedFileSet
  */
 fun PsiFile.referencedFiles(): Set<PsiFile> = TexifyUtil.getReferencedFileSet(this)
+
+/**
+ * Get the editor of the file if it is currently opened.
+ */
+fun PsiFile.openedEditor() = FileEditorManager.getInstance(project).selectedTextEditor
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //// LATEX ELEMENTS ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Changes
* After having inserted a label using the Missing Label inspection, the caret will be placed after the inserted label. (#133)