### PR TITLE
Anchored New Latex File action to the NewGroup group.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -85,7 +85,7 @@
     <actions>
         <!-- New LaTeX file -->
         <action id="texify.NewFile" class="nl.rubensten.texifyidea.action.NewLatexFileAction">
-            <add-to-group group-id="NewGroup1" anchor="after" relative-to-action="NewModuleInGroup"/>
+            <add-to-group group-id="NewGroup" anchor="after" relative-to-action="NewFile" />
         </action>
 
         <!-- LaTeX commands -->


### PR DESCRIPTION
# Changes
- Re-anchored the new latex file action to the `NewGroup` group, after the new file action.
- This fixes #121: the new file action missing in other JetBrains products.

# Pictures
![image](https://user-images.githubusercontent.com/17410729/30250452-d19b7b76-964e-11e7-8e52-be995ff7b1df.png)
