### PR TITLE
Documentclass: commands in autocomplete and contents in structure view.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -21,6 +21,7 @@ import nl.rubensten.texifyidea.completion.handlers.LatexNoMathInsertHandler;
 import nl.rubensten.texifyidea.index.LatexCommandsIndex;
 import nl.rubensten.texifyidea.lang.*;
 import nl.rubensten.texifyidea.psi.LatexCommands;
+import nl.rubensten.texifyidea.util.FileUtilKt;
 import nl.rubensten.texifyidea.util.PsiUtilKt;
 import nl.rubensten.texifyidea.util.TexifyUtil;
 import org.jetbrains.annotations.NotNull;
@@ -142,7 +143,14 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         }
 
         PsiFile file = parameters.getOriginalFile();
-        Set<VirtualFile> searchFiles = TexifyUtil.getReferencedFileSet(file).stream()
+        Set<PsiFile> files = TexifyUtil.getReferencedFileSet(file);
+        PsiFile root = FileUtilKt.findRootFile(file);
+        PsiFile documentClass = FileUtilKt.documentClassFile(root);
+        if (documentClass != null) {
+            files.add(documentClass);
+        }
+
+        Set<VirtualFile> searchFiles = files.stream()
                 .map(PsiFile::getVirtualFile)
                 .collect(Collectors.toSet());
         searchFiles.add(file.getVirtualFile());

--- a/src/nl/rubensten/texifyidea/structure/LatexIncludePresentation.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexIncludePresentation.java
@@ -18,7 +18,8 @@ public class LatexIncludePresentation implements ItemPresentation {
     public LatexIncludePresentation(LatexCommands labelCommand) {
         if (!labelCommand.getCommandToken().getText().equals("\\include") &&
                 !labelCommand.getCommandToken().getText().equals("\\includeonly") &&
-                !labelCommand.getCommandToken().getText().equals("\\input")) {
+                !labelCommand.getCommandToken().getText().equals("\\input") &&
+                !labelCommand.getCommandToken().getText().equals("\\documentclass")) {
             throw new IllegalArgumentException("command is no \\include(only)-command");
         }
 

--- a/src/nl/rubensten/texifyidea/structure/LatexPresentationFactory.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexPresentationFactory.java
@@ -33,10 +33,9 @@ public class LatexPresentationFactory {
             case "\\bibitem":
                 return new BibitemPresentation(commands);
             case "\\include":
-                return new LatexIncludePresentation(commands);
             case "\\includeonly":
-                return new LatexIncludePresentation(commands);
             case "\\input":
+            case "\\documentclass":
                 return new LatexIncludePresentation(commands);
             default:
                 return new LatexOtherCommandPresentation(commands, TexifyIcons.DOT_COMMAND);

--- a/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
+++ b/src/nl/rubensten/texifyidea/structure/LatexStructureViewElement.java
@@ -13,9 +13,7 @@ import com.intellij.psi.PsiNamedElement;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
-import nl.rubensten.texifyidea.file.LatexFile;
-import nl.rubensten.texifyidea.file.LatexFileType;
-import nl.rubensten.texifyidea.file.StyleFileType;
+import nl.rubensten.texifyidea.file.*;
 import nl.rubensten.texifyidea.index.LatexCommandsIndex;
 import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
 import nl.rubensten.texifyidea.lang.RequiredFileArgument;
@@ -98,7 +96,8 @@ public class LatexStructureViewElement implements StructureViewTreeElement, Sort
     @NotNull
     @Override
     public TreeElement[] getChildren() {
-        if (!(element instanceof LatexFile)) {
+        if (!(element instanceof LatexFile) && !(element instanceof StyleFile) &&
+                !(element instanceof ClassFile)) {
             return EMPTY_ARRAY;
         }
 
@@ -187,6 +186,24 @@ public class LatexStructureViewElement implements StructureViewTreeElement, Sort
     }
 
     private void addIncludes(List<TreeElement> treeElements, List<LatexCommands> commands) {
+        // Include documentclass.
+        if (!commands.isEmpty()) {
+            PsiFile baseFile = commands.get(0).getContainingFile();
+            PsiFile root = FileUtilKt.findRootFile(baseFile);
+            PsiFile documentClass = FileUtilKt.documentClassFile(root);
+            if (documentClass != null) {
+                LatexCommands command = LatexCommandsIndex.getIndexCommands(baseFile).stream()
+                        .filter(cmd -> "\\documentclass".equals(cmd.getName()))
+                        .findFirst().orElse(null);
+                if (command != null) {
+                    LatexStructureViewCommandElement elt = new LatexStructureViewCommandElement(command);
+                    elt.addChild(new LatexStructureViewElement(documentClass));
+                    treeElements.add(elt);
+                }
+            }
+        }
+
+        // Scan for normal includes.
         for (LatexCommands cmd : commands) {
             String name = cmd.getCommandToken().getText();
             if (!name.equals("\\include") && !name.equals("\\includeonly") && !name.equals("\\input")) {

--- a/src/nl/rubensten/texifyidea/util/FileUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/FileUtil.kt
@@ -128,3 +128,12 @@ fun PsiFile.isRoot(): Boolean {
  */
 fun PsiFile.isLatexFile() = fileType == LatexFileType.INSTANCE ||
         fileType == StyleFileType.INSTANCE || fileType == ClassFileType.INSTANCE
+
+/**
+ * Looks up the the that is in the documentclass command.
+ */
+fun PsiFile.documentClassFile(): PsiFile? {
+    val command = commandsInFile().filter { it.name == "\\documentclass" }.getOrNull(0) ?: return null
+    val argument = command.requiredParameter(0) ?: return null
+    return fileRelativeTo("$argument.cls")
+}


### PR DESCRIPTION
# Changes
- The contents of a used documentclass (where the cls is in your project) get displayed in the include part of the structure view.
- Commands defined in an included document class (where the cls is in your project) get added to the autocomplete, (#143)