### PR TITLE
Parser relaxation for nested math environments

### DIFF
--- a/gen/nl/rubensten/texifyidea/grammar/LatexLexer.java
+++ b/gen/nl/rubensten/texifyidea/grammar/LatexLexer.java
@@ -2,6 +2,9 @@
 
 package nl.rubensten.texifyidea.grammar;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import com.intellij.lexer.*;
 import com.intellij.psi.tree.IElementType;
 
@@ -130,15 +133,15 @@ public class LatexLexer implements FlexLexer {
     "\1\4\2\5\1\21\1\22\1\10\1\11\1\12\1\13"+
     "\1\5\1\14\7\4\1\15\1\16\1\15\1\23\1\20"+
     "\1\4\2\5\1\21\1\22\1\10\1\11\1\12\1\13"+
-    "\1\5\1\24\7\4\1\15\1\16\2\15\1\20\1\4"+
-    "\12\0\7\4\4\0\1\4\1\0\2\5\6\0\1\5"+
-    "\44\0\3\25\1\26\5\25\1\0\1\25\1\27\1\30"+
-    "\5\31\1\0\4\25\1\16\1\0\25\16\3\25\1\26"+
-    "\1\32\4\25\1\0\1\25\1\27\1\30\5\31\1\0"+
-    "\4\25\13\0\1\31\1\33\5\31\20\0\4\31\1\34"+
-    "\2\31\20\0\7\31\20\0\2\31\1\35\4\31\20\0"+
-    "\5\31\1\36\1\31\20\0\3\31\1\37\3\31\20\0"+
-    "\4\31\1\40\2\31\5\0";
+    "\1\5\1\24\7\4\1\15\1\16\1\15\1\17\1\20"+
+    "\1\4\12\0\7\4\4\0\1\4\1\0\2\5\6\0"+
+    "\1\5\44\0\3\25\1\26\5\25\1\0\1\25\1\27"+
+    "\1\30\5\31\1\0\4\25\1\16\1\0\25\16\3\25"+
+    "\1\26\1\32\4\25\1\0\1\25\1\27\1\30\5\31"+
+    "\1\0\4\25\13\0\1\31\1\33\5\31\20\0\4\31"+
+    "\1\34\2\31\20\0\7\31\20\0\2\31\1\35\4\31"+
+    "\20\0\5\31\1\36\1\31\20\0\3\31\1\37\3\31"+
+    "\20\0\4\31\1\40\2\31\5\0";
 
   private static int [] zzUnpackTrans() {
     int [] result = new int[368];
@@ -239,7 +242,17 @@ public class LatexLexer implements FlexLexer {
   private boolean zzEOFDone;
 
   /* user code: */
-  private boolean startedInlineMath = false;
+  private Deque<Integer> stack = new ArrayDeque<>();
+
+  public void yypushState(int newState) {
+    stack.push(yystate());
+    yybegin(newState);
+  }
+
+  public void yypopState() {
+    yybegin(stack.pop());
+  }
+
 
   public LatexLexer() {
     this((java.io.Reader)null);
@@ -531,7 +544,7 @@ public class LatexLexer implements FlexLexer {
             }
           case 30: break;
           case 11: 
-            { yybegin(INLINE_MATH); return INLINE_MATH_START;
+            { yypushState(INLINE_MATH); return INLINE_MATH_START;
             }
           case 31: break;
           case 12: 
@@ -547,7 +560,7 @@ public class LatexLexer implements FlexLexer {
             }
           case 34: break;
           case 15: 
-            { yybegin(YYINITIAL); return INLINE_MATH_END;
+            { yypopState(); return INLINE_MATH_END;
             }
           case 35: break;
           case 16: 
@@ -555,11 +568,11 @@ public class LatexLexer implements FlexLexer {
             }
           case 36: break;
           case 17: 
-            { yybegin(DISPLAY_MATH); return DISPLAY_MATH_START;
+            { yypushState(DISPLAY_MATH); return DISPLAY_MATH_START;
             }
           case 37: break;
           case 18: 
-            { yybegin(YYINITIAL); return DISPLAY_MATH_END;
+            { yypopState(); return DISPLAY_MATH_END;
             }
           case 38: break;
           case 19: 

--- a/gen/nl/rubensten/texifyidea/parser/LatexParser.java
+++ b/gen/nl/rubensten/texifyidea/parser/LatexParser.java
@@ -166,13 +166,12 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // no_math_content | math_environment
+  // no_math_content
   public static boolean content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "content")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, CONTENT, "<content>");
     r = no_math_content(b, l + 1);
-    if (!r) r = math_environment(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
@@ -360,13 +359,14 @@ public class LatexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // comment | environment | commands | group | open_group | OPEN_PAREN | CLOSE_PAREN | M_OPEN_BRACKET | M_CLOSE_BRACKET | normal_text
+  // comment | environment | math_environment | commands | group | open_group | OPEN_PAREN | CLOSE_PAREN | M_OPEN_BRACKET | M_CLOSE_BRACKET | normal_text
   public static boolean no_math_content(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "no_math_content")) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, NO_MATH_CONTENT, "<no math content>");
     r = comment(b, l + 1);
     if (!r) r = environment(b, l + 1);
+    if (!r) r = math_environment(b, l + 1);
     if (!r) r = commands(b, l + 1);
     if (!r) r = group(b, l + 1);
     if (!r) r = open_group(b, l + 1);

--- a/gen/nl/rubensten/texifyidea/psi/LatexContent.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexContent.java
@@ -7,10 +7,7 @@ import com.intellij.psi.PsiElement;
 
 public interface LatexContent extends PsiElement {
 
-  @Nullable
-  LatexMathEnvironment getMathEnvironment();
-
-  @Nullable
+  @NotNull
   LatexNoMathContent getNoMathContent();
 
 }

--- a/gen/nl/rubensten/texifyidea/psi/LatexNoMathContent.java
+++ b/gen/nl/rubensten/texifyidea/psi/LatexNoMathContent.java
@@ -20,6 +20,9 @@ public interface LatexNoMathContent extends PsiElement {
   LatexGroup getGroup();
 
   @Nullable
+  LatexMathEnvironment getMathEnvironment();
+
+  @Nullable
   LatexNormalText getNormalText();
 
   @Nullable

--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexContentImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexContentImpl.java
@@ -27,15 +27,9 @@ public class LatexContentImpl extends ASTWrapperPsiElement implements LatexConte
   }
 
   @Override
-  @Nullable
-  public LatexMathEnvironment getMathEnvironment() {
-    return findChildByClass(LatexMathEnvironment.class);
-  }
-
-  @Override
-  @Nullable
+  @NotNull
   public LatexNoMathContent getNoMathContent() {
-    return findChildByClass(LatexNoMathContent.class);
+    return findNotNullChildByClass(LatexNoMathContent.class);
   }
 
 }

--- a/gen/nl/rubensten/texifyidea/psi/impl/LatexNoMathContentImpl.java
+++ b/gen/nl/rubensten/texifyidea/psi/impl/LatexNoMathContentImpl.java
@@ -52,6 +52,12 @@ public class LatexNoMathContentImpl extends ASTWrapperPsiElement implements Late
 
   @Override
   @Nullable
+  public LatexMathEnvironment getMathEnvironment() {
+    return findChildByClass(LatexMathEnvironment.class);
+  }
+
+  @Override
+  @Nullable
   public LatexNormalText getNormalText() {
     return findChildByClass(LatexNormalText.class);
   }

--- a/src/nl/rubensten/texifyidea/grammar/Latex.bnf
+++ b/src/nl/rubensten/texifyidea/grammar/Latex.bnf
@@ -31,9 +31,9 @@
 
 latexFile ::= content*
 
-content ::= no_math_content | math_environment
+content ::= no_math_content
 
-no_math_content ::= comment | environment | commands | group | open_group | OPEN_PAREN | CLOSE_PAREN | M_OPEN_BRACKET | M_CLOSE_BRACKET | normal_text
+no_math_content ::= comment | environment | math_environment | commands | group | open_group | OPEN_PAREN | CLOSE_PAREN | M_OPEN_BRACKET | M_CLOSE_BRACKET | normal_text
 
 normal_text ::= NORMAL_TEXT_WORD+
 

--- a/src/nl/rubensten/texifyidea/psi/LatexPsiUtil.java
+++ b/src/nl/rubensten/texifyidea/psi/LatexPsiUtil.java
@@ -139,7 +139,6 @@ public class LatexPsiUtil {
         // LatexContent
         else if (element instanceof LatexContent) {
             LatexContent content = (LatexContent)element;
-            result.add(content.getMathEnvironment());
             result.add(content.getNoMathContent());
         }
         // LatexDisplayMath


### PR DESCRIPTION
Resolves #61.

Needed because the state of (non-)math mode cannot accurately be presumed at parser/lexer level.