### PR TITLE
Support for \RequirePackage and packages loaded in documentclass

### DIFF
--- a/src/nl/rubensten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/rubensten/texifyidea/action/analysis/WordCountAction.kt
@@ -36,7 +36,7 @@ open class WordCountAction : AnAction(
                 "\\usepackage", "\\documentclass", "\\label", "\\linespread", "\\ref", "\\cite", "\\eqref", "\\nameref",
                 "\\autoref", "\\fullref", "\\pageref", "\\newcounter", "\\newcommand", "\\renewcommand",
                 "\\setcounter", "\\resizebox", "\\includegraphics", "\\include", "\\input", "\\refstepcounter",
-                "\\counterwithins"
+                "\\counterwithins", "\\RequirePackage"
         )
 
         /**

--- a/src/nl/rubensten/texifyidea/index/LatexCommandsIndex.java
+++ b/src/nl/rubensten/texifyidea/index/LatexCommandsIndex.java
@@ -9,6 +9,7 @@ import com.intellij.psi.stubs.StubIndex;
 import com.intellij.psi.stubs.StubIndexKey;
 import com.intellij.util.ArrayUtil;
 import nl.rubensten.texifyidea.psi.LatexCommands;
+import nl.rubensten.texifyidea.util.FileUtilKt;
 import nl.rubensten.texifyidea.util.TexifyUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,6 +39,14 @@ public class LatexCommandsIndex extends StringStubIndexExtension<LatexCommands> 
                 .map(PsiFile::getVirtualFile)
                 .collect(Collectors.toSet());
         searchFiles.add(baseFile.getVirtualFile());
+
+        // Add document class
+        PsiFile root = FileUtilKt.findRootFile(baseFile);
+        PsiFile documentClass = FileUtilKt.documentClassFile(root);
+        if (documentClass != null) {
+            searchFiles.add(documentClass.getVirtualFile());
+        }
+
         GlobalSearchScope scope = GlobalSearchScope.filesScope(project, searchFiles);
         return LatexCommandsIndex.getIndexedCommands(project, scope);
     }

--- a/src/nl/rubensten/texifyidea/util/FileUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/FileUtil.kt
@@ -130,6 +130,16 @@ fun PsiFile.isLatexFile() = fileType == LatexFileType.INSTANCE ||
         fileType == StyleFileType.INSTANCE || fileType == ClassFileType.INSTANCE
 
 /**
+ * Checks if the file has a `.sty` extention. This is a workaround for file type checking.
+ */
+fun PsiFile.isStyleFile() = virtualFile.extension == "sty"
+
+/**
+ * Checks if the file has a `.cls` extention. This is a workaround for file type checking.
+ */
+fun PsiFile.isClassFile() = virtualFile.extension == "cls"
+
+/**
  * Looks up the the that is in the documentclass command.
  */
 fun PsiFile.documentClassFile(): PsiFile? {

--- a/src/nl/rubensten/texifyidea/util/PackageUtils.kt
+++ b/src/nl/rubensten/texifyidea/util/PackageUtils.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiFile
 import nl.rubensten.texifyidea.index.LatexCommandsIndex
 import nl.rubensten.texifyidea.lang.Package
 import nl.rubensten.texifyidea.psi.LatexCommands
-
 import java.util.*
 
 /**
@@ -31,27 +30,34 @@ object PackageUtils {
                          parameters: String?) {
         val commands = LatexCommandsIndex.getIndexCommands(file)
 
+        val commandName = if (file.isStyleFile() || file.isClassFile()) "\\RequirePackage" else "\\usepackage"
+
         var last: LatexCommands? = null
         for (cmd in commands) {
-            if ("\\usepackage" == cmd.commandToken.text) {
+            if (commandName == cmd.commandToken.text) {
                 last = cmd
             }
         }
 
-        val newlines: String?
+        val newlines: String
         val insertLocation: Int
+        var postNewlines: String? = null
 
         // When there are no usepackage commands: insert below documentclass.
         if (last == null) {
             val classHuh = commands.stream()
-                    .filter { cmd -> "\\documentclass" == cmd.commandToken.text }
+                    .filter { cmd -> "\\documentclass" == cmd.commandToken.text || "\\LoadClass" == cmd.commandToken.text }
                     .findFirst()
-            if (!classHuh.isPresent) {
-                return
+            if (classHuh.isPresent) {
+                insertLocation = classHuh.get().textOffset + classHuh.get().textLength
+                newlines = "\n\n"
+            } else {
+                // No other sensible location can be found
+                insertLocation = 0
+                newlines = ""
+                postNewlines = "\n\n"
             }
 
-            insertLocation = classHuh.get().textOffset + classHuh.get().textLength
-            newlines = "\n\n"
         }
         // Otherwise, insert below the lowest usepackage.
         else {
@@ -59,9 +65,13 @@ object PackageUtils {
             newlines = "\n"
         }
 
-        var command = newlines + "\\usepackage"
+        var command = newlines + commandName
         command += if (parameters == null || "" == parameters) "" else "[$parameters]"
         command += "{$packageName}"
+
+        if (postNewlines != null) {
+            command += postNewlines
+        }
 
         runWriteAction {
             document.insertString(insertLocation, command)

--- a/src/nl/rubensten/texifyidea/util/PackageUtils.kt
+++ b/src/nl/rubensten/texifyidea/util/PackageUtils.kt
@@ -14,6 +14,8 @@ import java.util.*
  */
 object PackageUtils {
 
+    private val PACKAGE_COMMANDS = setOf("\\usepackage", "\\RequirePackage")
+
     /**
      * Inserts a usepackage statement for the given package in a certain file.
      *
@@ -106,7 +108,7 @@ object PackageUtils {
         val packages = HashSet<String>()
 
         for (cmd in commands) {
-            if ("\\usepackage" != cmd.commandToken.text) {
+            if (cmd.commandToken.text !in PACKAGE_COMMANDS) {
                 continue
             }
 


### PR DESCRIPTION
Fixes #147.

- `\RequirePackage` now behaves the same as `\usepackage`.
- Packages loaded in the document class are now in the included packages index

Implementation note: all commands from the documentclass are now loaded in the indexed commands in the file set.