### PR TITLE
Inclusion index & Usepackage/RequirePackage integration

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -254,6 +254,7 @@
         <stubElementTypeHolder class="nl.rubensten.texifyidea.psi.LatexTypes"/>
 
         <stubIndex implementation="nl.rubensten.texifyidea.index.LatexCommandsIndex"/>
+        <stubIndex implementation="nl.rubensten.texifyidea.index.LatexIncludesIndex"/>
 
         <!-- Documentation -->
         <lang.documentationProvider language="Latex" implementationClass="nl.rubensten.texifyidea.documentation.LatexDocumentationProvider"/>

--- a/src/nl/rubensten/texifyidea/gutter/LatexNavigationGutter.java
+++ b/src/nl/rubensten/texifyidea/gutter/LatexNavigationGutter.java
@@ -47,21 +47,31 @@ public class LatexNavigationGutter extends RelatedItemLineMarkerProvider {
             return;
         }
 
+        // True when it doesnt have a required file argument, but must be handled.
+        boolean ignoreFileArgument = "\\RequirePackage".equals(fullCommand) ||
+                "\\usepackage".equals(fullCommand);
+
         // Fetch the corresponding LatexNoMathCommand object.
         String commandName = fullCommand.substring(1);
         LatexNoMathCommand commandHuh = LatexNoMathCommand.get(commandName);
-        if (commandHuh == null) {
+        if (commandHuh == null && !ignoreFileArgument) {
             return;
         }
 
         List<RequiredFileArgument> arguments = commandHuh.getArgumentsOf(RequiredFileArgument.class);
-
-        if (arguments.isEmpty()) {
+        if (arguments.isEmpty() && !ignoreFileArgument) {
             return;
         }
 
         // Get the required file arguments.
-        RequiredFileArgument argument = arguments.get(0);
+        RequiredFileArgument argument;
+        if (ignoreFileArgument) {
+            argument = new RequiredFileArgument("", "sty");
+        }
+        else {
+            argument = arguments.get(0);
+        }
+
         List<LatexRequiredParam> requiredParams = TexifyUtil.getRequiredParameters(commands);
         if (requiredParams.isEmpty()) {
             return;

--- a/src/nl/rubensten/texifyidea/index/LatexIncludesIndex.java
+++ b/src/nl/rubensten/texifyidea/index/LatexIncludesIndex.java
@@ -1,0 +1,85 @@
+package nl.rubensten.texifyidea.index;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.StringStubIndexExtension;
+import com.intellij.psi.stubs.StubIndex;
+import com.intellij.psi.stubs.StubIndexKey;
+import com.intellij.util.ArrayUtil;
+import nl.rubensten.texifyidea.psi.LatexCommands;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Pattern;
+
+/**
+ * @author Ruben Schellekens
+ */
+public class LatexIncludesIndex extends StringStubIndexExtension<LatexCommands> {
+
+    public static final StubIndexKey<String, LatexCommands> KEY =
+            StubIndexKey.createIndexKey("nl.rubensten.texifyidea.includes");
+
+    private static final Pattern PRECEDING_SLASH = Pattern.compile("^\\\\");
+
+    @NotNull
+    public static Collection<LatexCommands> getIncludes(@NotNull Project project) {
+        GlobalSearchScope scope = GlobalSearchScope.projectScope(project);
+        return getIncludes(project, scope);
+    }
+
+    @NotNull
+    public static Collection<LatexCommands> getIncludes(@NotNull Project project,
+                                                        @NotNull GlobalSearchScope scope) {
+        Collection<LatexCommands> commands = new ArrayList<>();
+
+        for (String key : getKeys(project)) {
+            commands.addAll(getIncludesByName(key, project, scope));
+        }
+
+        return commands;
+    }
+
+    @NotNull
+    public static Collection<LatexCommands> getIndexedIncludesByName(@NotNull String name,
+                                                                     @NotNull Project project,
+                                                                     @NotNull GlobalSearchScope scope) {
+        Collection<LatexCommands> commands = new ArrayList<>();
+
+        for (String key : getKeys(project)) {
+            Collection<LatexCommands> cmds = getIncludesByName(key, project, scope);
+
+            for (LatexCommands cmd : cmds) {
+                String cmdToken = PRECEDING_SLASH.matcher(cmd.getCommandToken().getText()).replaceFirst("");
+                String matchTo = PRECEDING_SLASH.matcher(name).replaceFirst("");
+
+                if (!cmdToken.equals(matchTo)) {
+                    continue;
+                }
+
+                commands.add(cmd);
+            }
+        }
+
+        return commands;
+    }
+
+    @NotNull
+    public static Collection<LatexCommands> getIncludesByName(@NotNull String name,
+                                                              @NotNull Project project,
+                                                              @NotNull GlobalSearchScope scope) {
+        return StubIndex.getElements(KEY, name, project, scope, LatexCommands.class);
+    }
+
+    @NotNull
+    public static String[] getKeys(@NotNull Project project) {
+        return ArrayUtil.toStringArray(StubIndex.getInstance().getAllKeys(LatexCommandsIndex.KEY, project));
+    }
+
+    @NotNull
+    @Override
+    public StubIndexKey<String, LatexCommands> getKey() {
+        return KEY;
+    }
+}

--- a/src/nl/rubensten/texifyidea/index/stub/LatexCommandsStubElementType.java
+++ b/src/nl/rubensten/texifyidea/index/stub/LatexCommandsStubElementType.java
@@ -3,8 +3,10 @@ package nl.rubensten.texifyidea.index.stub;
 import com.intellij.psi.stubs.*;
 import nl.rubensten.texifyidea.LatexLanguage;
 import nl.rubensten.texifyidea.index.LatexCommandsIndex;
+import nl.rubensten.texifyidea.index.LatexIncludesIndex;
 import nl.rubensten.texifyidea.psi.LatexCommands;
 import nl.rubensten.texifyidea.psi.impl.LatexCommandsImpl;
+import nl.rubensten.texifyidea.util.TexifyUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -78,6 +80,10 @@ public class LatexCommandsStubElementType extends IStubElementType<LatexCommands
     @Override
     public void indexStub(@NotNull LatexCommandsStub latexCommandsStub, @NotNull IndexSink indexSink) {
         indexSink.occurrence(LatexCommandsIndex.KEY, latexCommandsStub.getCommandToken());
+
+        if (TexifyUtil.INCLUDE_COMMANDS.contains(latexCommandsStub.getCommandToken())) {
+            indexSink.occurrence(LatexIncludesIndex.KEY, latexCommandsStub.getCommandToken());
+        }
     }
 
     @NotNull

--- a/src/nl/rubensten/texifyidea/lang/Diacritic.kt
+++ b/src/nl/rubensten/texifyidea/lang/Diacritic.kt
@@ -1,7 +1,6 @@
 package nl.rubensten.texifyidea.lang
 
 /**
- *
  * @author Sten Wessel
  */
 interface Diacritic {

--- a/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.kt
+++ b/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.kt
@@ -4,7 +4,6 @@ import nl.rubensten.texifyidea.lang.Argument.Type
 import nl.rubensten.texifyidea.lang.Package.*
 
 /**
- *
  * @author Sten Wessel
  */
 enum class LatexNoMathCommand(
@@ -176,6 +175,7 @@ enum class LatexNoMathCommand(
     R("r", display = "˚ (accent)"),
     REF("ref", "label".asRequired()),
     REFNAME("refname", "name".asRequired(Type.TEXT)),
+    REQUIREPACKAGE("RequirePackage", "options".asOptional(), "package".asRequired()),
     RIGHTHYPHENMIN("righthyphenmin"),
     RIGHTMARGIN("rightmargin"),
     RIGHTMARK("rightmark"),

--- a/src/nl/rubensten/texifyidea/lang/RequiredFileArgument.java
+++ b/src/nl/rubensten/texifyidea/lang/RequiredFileArgument.java
@@ -29,7 +29,7 @@ public class RequiredFileArgument extends RequiredArgument implements FileNameMa
      * @param extensions
      *         All supported extensions.
      */
-    protected RequiredFileArgument(String name, String... extensions) {
+    public RequiredFileArgument(String name, String... extensions) {
         super(name, Type.FILE);
         setExtensions(extensions);
     }

--- a/src/nl/rubensten/texifyidea/util/TexifyUtil.java
+++ b/src/nl/rubensten/texifyidea/util/TexifyUtil.java
@@ -18,6 +18,7 @@ import nl.rubensten.texifyidea.file.ClassFileType;
 import nl.rubensten.texifyidea.file.LatexFileType;
 import nl.rubensten.texifyidea.file.StyleFileType;
 import nl.rubensten.texifyidea.index.LatexCommandsIndex;
+import nl.rubensten.texifyidea.index.LatexIncludesIndex;
 import nl.rubensten.texifyidea.lang.LatexMathCommand;
 import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
 import nl.rubensten.texifyidea.psi.*;
@@ -53,8 +54,12 @@ public class TexifyUtil {
     }
 
     // Referenced files.
-    private static final List<String> INCLUDE_COMMANDS = Arrays.asList("\\includeonly", "\\include", "\\input");
-    private static final Set<String> INCLUDE_EXTENSIONS = new HashSet<>();
+    public static final Set<String> INCLUDE_COMMANDS = new HashSet<>();
+    static {
+        Collections.addAll(INCLUDE_COMMANDS, "\\includeonly", "\\include", "\\input", "\\usepackage", "\\RequirePackage");
+    }
+
+    public static final Set<String> INCLUDE_EXTENSIONS = new HashSet<>();
     static {
         Collections.addAll(INCLUDE_EXTENSIONS, "tex", "sty", "cls");
     }
@@ -115,8 +120,7 @@ public class TexifyUtil {
      */
     public static Set<PsiFile> getReferencedFileSet(@NotNull PsiFile psiFile) {
         Project project = psiFile.getProject();
-        GlobalSearchScope scope = GlobalSearchScope.allScope(project);
-        Collection<LatexCommands> commands = LatexCommandsIndex.getIndexedCommands(project, scope);
+        Collection<LatexCommands> commands = LatexIncludesIndex.getIncludes(project);
 
         // Contains the end result.
         Set<PsiFile> set = new HashSet<>();


### PR DESCRIPTION
# Changes
- Included `\usepackage` and `\RequirePackage` into inclusion loop detection. (Fixes #162)
- Added new index for inclusion commands.
- Added navigation gutter icons for `\usepackage` and `\RequirePackage` that have a local style file.

# Pictures
![image](https://user-images.githubusercontent.com/17410729/30525052-5755b834-9bff-11e7-8258-1d9c04efedec.png)
