### PR TITLE
Advanced syntax highlighting of the comment environment.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -159,7 +159,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         Collection<LatexCommands> cmds = LatexCommandsIndex.getIndexedCommands(project, scope);
 
         for (LatexCommands cmd : cmds) {
-            if (!isDefinition(cmd)) {
+            if (!PsiUtilKt.isDefinition(cmd) && !PsiUtilKt.isEnvironmentDefinition(cmd)) {
                 continue;
             }
 
@@ -271,14 +271,5 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         }
 
         return next.getCommandToken().getText();
-    }
-
-    private boolean isDefinition(@Nullable LatexCommands commands) {
-        return commands != null && (
-                "\\newcommand".equals(commands.getCommandToken().getText()) ||
-                        "\\let".equals(commands.getCommandToken().getText()) ||
-                        "\\def".equals(commands.getCommandToken().getText()) ||
-                        "\\DeclareMathOperator".equals(commands.getCommandToken().getText())
-        );
     }
 }

--- a/src/nl/rubensten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
+++ b/src/nl/rubensten/texifyidea/completion/handlers/LatexNoMathInsertHandler.kt
@@ -10,9 +10,7 @@ import com.intellij.codeInsight.template.impl.TemplateSettings
 import com.intellij.codeInsight.template.impl.TemplateState
 import nl.rubensten.texifyidea.lang.Environment
 import nl.rubensten.texifyidea.lang.LatexCommand
-import nl.rubensten.texifyidea.util.PackageUtils
-import nl.rubensten.texifyidea.util.insertAndMove
-import nl.rubensten.texifyidea.util.insertUsepackage
+import nl.rubensten.texifyidea.util.*
 
 /**
  * @author Ruben Schellekens, Sten Wessel
@@ -57,9 +55,12 @@ class LatexNoMathInsertHandler : InsertHandler<LookupElement> {
             val pack = environment.dependency
             val file = context.file
             val editor = context.editor
+            val envDefinitions = file.definitionsAndRedefinitions()
+                    .filter { it.isEnvironmentDefinition() }
+                    .mapNotNull { it.requiredParameter(0) }.toSet()
 
             // Include packages.
-            if (!PackageUtils.getIncludedPackages(file).contains(pack.name)) {
+            if (!PackageUtils.getIncludedPackages(file).contains(pack.name) && envName !in envDefinitions) {
                 file.insertUsepackage(pack)
             }
 

--- a/src/nl/rubensten/texifyidea/util/FileUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/FileUtil.kt
@@ -11,6 +11,7 @@ import nl.rubensten.texifyidea.file.ClassFileType
 import nl.rubensten.texifyidea.file.LatexFileType
 import nl.rubensten.texifyidea.file.StyleFileType
 import nl.rubensten.texifyidea.index.LatexCommandsIndex
+import nl.rubensten.texifyidea.lang.Package
 import java.util.*
 import java.util.regex.Pattern
 
@@ -147,3 +148,21 @@ fun PsiFile.documentClassFile(): PsiFile? {
     val argument = command.requiredParameter(0) ?: return null
     return fileRelativeTo("$argument.cls")
 }
+
+/**
+ * Checks if the given package is included in the file set.
+ *
+ * @param packageName
+ *          The name of the package to check for.
+ * @return `true` when there is a package with name `packageName` in the file set, `false` otherwise.
+ */
+fun PsiFile.isUsed(packageName: String) = PackageUtils.getIncludedPackages(this).contains(packageName)
+
+/**
+ * Checks if the given package is included into the file set.
+ *
+ * @param `package`
+ *          The package to check for.
+ * @return `true` when there is a package `package` included in the file set, `false` otherwise.
+ */
+fun PsiFile.isUsed(`package`: Package) = isUsed(`package`.name)

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -279,9 +279,84 @@ fun PsiFile.referencedFiles(): Set<PsiFile> = TexifyUtil.getReferencedFileSet(th
  */
 fun PsiFile.openedEditor() = FileEditorManager.getInstance(project).selectedTextEditor
 
+/**
+ * Get all the definitions in the file set.
+ */
+fun PsiFile.definitions(): Collection<LatexCommands> {
+    // TODO: To be replaced with a call to future definition index.
+    return LatexCommandsIndex.getIndexCommandsInFileSet(this)
+            .filter { it.isDefinition() }
+}
+
+/**
+ * Get all the definitions and redefinitions in the file set.
+ */
+fun PsiFile.definitionsAndRedefinitions(): Collection<LatexCommands> {
+    // TODO: To be replaced with a call to future definition index.
+    return LatexCommandsIndex.getIndexCommandsInFileSet(this)
+            .filter { it.isDefinitionOrRedefinition() }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //// LATEX ELEMENTS ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Checks whether the given LaTeX commands is a (re)definition or not.
+ *
+ * This is either a command definition or an environment (re)definition.
+ *
+ * @return `true` if the command is an environment (re)definition or a command (re)definition, `false` when the command is
+ *         `null` or otherwise.
+ */
+fun LatexCommands?.isDefinitionOrRedefinition(): Boolean {
+    return this != null && ("\\newcommand" == name ||
+            "\\let" == name ||
+            "\\def" == name ||
+            "\\DeclareMathOperator" == name ||
+            "\\newenvironment" == name ||
+            "\\renewcommand" == name ||
+            "\\renewenvironment" == name)
+}
+
+/**
+ * Checks whether the given LaTeX commands is a definition or not.
+ *
+ * This is either a command definition or an environment definition. Does not count redefinitions.
+ *
+ * @return `true` if the command is an environment definition or a command definition, `false` when the command is
+ *         `null` or otherwise.
+ */
+fun LatexCommands?.isDefinition(): Boolean {
+    return this != null && ("\\newcommand" == name ||
+            "\\let" == name ||
+            "\\def" == name ||
+            "\\DeclareMathOperator" == name ||
+            "\\newenvironment" == name)
+}
+
+/**
+ * Checks whether the given LaTeX commands is a command definition or not.
+ *
+ * @return `true` if the command is a command definition, `false` when the command is `null` or otherwise.
+ */
+fun LatexCommands?.isCommandDefinition(): Boolean {
+    return this != null && ("\\newcommand" == name ||
+            "\\let" == name ||
+            "\\def" == name ||
+            "\\DeclareMathOperator" == name ||
+            "\\renewcommand" == name)
+}
+
+/**
+ * Checks whether the given LaTeX commands is an environment definition or not.
+ *
+ * @return `true` if the command is an environment definition, `false` when the command is `null` or otherwise.
+ */
+fun LatexCommands?.isEnvironmentDefinition(): Boolean {
+    return this != null && ("\\newenvironment" == name ||
+            "\\renewenvironment" == name)
+}
 
 /**
  * @see TexifyUtil.getNextCommand


### PR DESCRIPTION
# Changes
- Whenever a comment environment is defined, comment environments won't get syntax highlighting for comments.
- For performance reasons, the definition check happens only once every 40 annotation checks (cache).
- Also the MissingImport inspection takes definitions into account.
- Whenever comment environments are defined, `\usepackage{comment}` won't be auto-inserted.