### PR TITLE
Package inclusion by Unicode inspection now inserts fewer newlines

### DIFF
--- a/src/nl/rubensten/texifyidea/util/PackageUtils.kt
+++ b/src/nl/rubensten/texifyidea/util/PackageUtils.kt
@@ -38,8 +38,7 @@ object PackageUtils {
      *              Parameters to add to the statement, `null` or empty string for no parameters.
      */
     @JvmStatic
-    fun insertUsepackage(document: Document, file: PsiFile, packageName: String,
-                         parameters: String?) {
+    fun insertUsepackage(document: Document, file: PsiFile, packageName: String, parameters: String?) {
         val commands = LatexCommandsIndex.getIndexCommands(file)
 
         val commandName = if (file.isStyleFile() || file.isClassFile()) "\\RequirePackage" else "\\usepackage"
@@ -51,6 +50,7 @@ object PackageUtils {
             }
         }
 
+        val preNew: String
         val newlines: String
         val insertLocation: Int
         var postNewlines: String? = null
@@ -62,12 +62,15 @@ object PackageUtils {
                     .findFirst()
             if (classHuh.isPresent) {
                 insertLocation = classHuh.get().textOffset + classHuh.get().textLength
-                newlines = "\n\n"
-            } else {
+                newlines = "\n"
+                preNew = ""
+            }
+            else {
                 // No other sensible location can be found
                 insertLocation = 0
                 newlines = ""
                 postNewlines = "\n\n"
+                preNew = ""
             }
 
         }
@@ -75,9 +78,10 @@ object PackageUtils {
         else {
             insertLocation = last.textOffset + last.textLength
             newlines = "\n"
+            preNew = ""
         }
 
-        var command = newlines + commandName
+        var command = preNew + newlines + commandName
         command += if (parameters == null || "" == parameters) "" else "[$parameters]"
         command += "{$packageName}"
 
@@ -85,9 +89,7 @@ object PackageUtils {
             command += postNewlines
         }
 
-        runWriteAction {
-            document.insertString(insertLocation, command)
-        }
+        document.insertString(insertLocation, command)
     }
 
     /**


### PR DESCRIPTION
# Changes
- Whenever there are no usepackages in the file, and the unicode include packages option is selected, the packages will be inserted directly underneath the documentclass. The problem was that the 2nd usepackage is still recognised as a 1st use of usepackage as the first command is not properly indexed before the 2nd one gets included. This makes it hard to do some logic on it. This workaround just removes all extra newlines, so it is glued to the documentclass. `\endramble` Resolves #168 

# Pictures
![image](https://user-images.githubusercontent.com/17410729/30782334-9012ef08-a130-11e7-9e11-c57177d70418.png)
