### PR TITLE
Fixed auto insertion of sub/superscript after _ or ^

### DIFF
--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -10,14 +10,10 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import nl.rubensten.texifyidea.file.LatexFileType
 import nl.rubensten.texifyidea.psi.LatexMathContent
-import nl.rubensten.texifyidea.psi.LatexMathEnvironment
 import nl.rubensten.texifyidea.psi.LatexNoMathContent
 import nl.rubensten.texifyidea.psi.LatexNormalText
 import nl.rubensten.texifyidea.psi.LatexTypes.*
-import nl.rubensten.texifyidea.util.firstChildOfType
-import nl.rubensten.texifyidea.util.hasParent
-import nl.rubensten.texifyidea.util.lastChildOfType
-import nl.rubensten.texifyidea.util.previousSiblingIgnoreWhitespace
+import nl.rubensten.texifyidea.util.*
 import java.util.regex.Pattern
 
 /**
@@ -82,7 +78,7 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
                     }
                 }
 
-                return@exit null
+                return@exit element.parentOfType(LatexNormalText::class)
             }
             is PsiComment -> {
                 // When for some reason people want to insert it directly before a comment.
@@ -116,7 +112,7 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
 
     private fun handleNormalText(normalText: LatexNormalText, editor: Editor, char: Char) {
         // Check if in math environment.
-        if (!normalText.hasParent(LatexMathEnvironment::class)) {
+        if (!normalText.inMathContext()) {
             return
         }
 

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -58,14 +58,15 @@ fun <T : PsiElement> PsiElement.firstChildOfType(clazz: KClass<T>): T? {
  */
 @Suppress("UNCHECKED_CAST")
 fun <T : PsiElement> PsiElement.lastChildOfType(clazz: KClass<T>): T? {
-    val children = this.children
-    for (i in children.size - 1 downTo 0) {
-        val child = children[i]
-        if (child.javaClass.isAssignableFrom(clazz.java)) {
+    for (child in children.reversedArray()) {
+        if (clazz.java.isAssignableFrom(child.javaClass)) {
             return child as? T
         }
 
-        return child.firstChildOfType(clazz)
+        val last = child.lastChildOfType(clazz)
+        if (last != null) {
+            return last
+        }
     }
 
     return null


### PR DESCRIPTION
# Changes
- Auto insertion of `{}` after `_` and `^` now works in math-esque environments.
- Fixed that the editor doesn't recognise auto insertion cases correctly in certain cases.
- Fixed `PsiUtilKt#lastChildOfType` not performing instance check correctly.