### PR TITLE
Execute forward search after compilation.

### DIFF
--- a/src/nl/rubensten/texifyidea/action/sumatra/ForwardSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ForwardSearchAction.kt
@@ -34,8 +34,8 @@ open class ForwardSearchAction : EditorAction(
 
         try {
             SumatraConversation.forwardSearch(sourceFilePath = file.path, line = line)
-        } catch (ignored: TeXception) {
-
+        }
+        catch (ignored: TeXception) {
         }
     }
 


### PR DESCRIPTION
# Changes
- After compilation, the cursor's location will be highlighted in SumatraPDF.
- Uses a delay of 500ms so it also works when the program gets booted.