### PR TITLE
Made inspections ignore comments by default.

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/TexifyInspectionBase.java
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyInspectionBase.java
@@ -3,10 +3,12 @@ package nl.rubensten.texifyidea.inspections;
 import com.intellij.codeInspection.InspectionManager;
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.ProblemDescriptor;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import kotlin.reflect.jvm.internal.impl.utils.SmartList;
 import nl.rubensten.texifyidea.file.LatexFile;
 import nl.rubensten.texifyidea.insight.InsightGroup;
+import nl.rubensten.texifyidea.util.PsiUtilKt;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,7 +55,19 @@ public abstract class TexifyInspectionBase extends LocalInspectionTool {
         }
 
         List<ProblemDescriptor> descriptors = inspectFile(file, manager, isOnTheFly);
+        descriptors.removeIf(descriptor -> !checkContext(descriptor.getPsiElement()));
         return descriptors.toArray(new ProblemDescriptor[descriptors.size()]);
+    }
+
+    /**
+     * Checks if the element is in the correct context.
+     *
+     * By default returns `false` when in comments.
+     *
+     * @return `true` if the inspection is allowed in the context, `false` otherwise.
+     */
+    public boolean checkContext(@NotNull PsiElement element) {
+        return !PsiUtilKt.isComment(element);
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -8,12 +8,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.impl.source.tree.LeafPsiElement
 import nl.rubensten.texifyidea.insight.InsightGroup
-import nl.rubensten.texifyidea.psi.LatexTypes
 import nl.rubensten.texifyidea.util.document
 import nl.rubensten.texifyidea.util.hasParent
 import nl.rubensten.texifyidea.util.inMathContext
+import nl.rubensten.texifyidea.util.isComment
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import kotlin.reflect.jvm.internal.impl.utils.SmartList
@@ -109,6 +108,7 @@ abstract class TexifyRegexInspection(
     override fun getDisplayName() = inspectionDisplayName
     override fun getInspectionId() = myInspectionId
     override fun getInspectionGroup() = group
+    override fun checkContext(element: PsiElement) = true
 
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): MutableList<ProblemDescriptor> {
         val descriptors = SmartList<ProblemDescriptor>()
@@ -162,7 +162,7 @@ abstract class TexifyRegexInspection(
      * @return `true` if the inspection is allowed in the context, `false` otherwise.
      */
     open fun checkContext(matcher: Matcher, element: PsiElement): Boolean {
-        if (element is LeafPsiElement && element.elementType == LatexTypes.COMMENT_TOKEN) {
+        if (element.isComment()) {
             return false
         }
 

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import nl.rubensten.texifyidea.index.LatexCommandsIndex
 import nl.rubensten.texifyidea.index.LatexDefinitionIndex
@@ -85,6 +86,14 @@ fun <T : PsiElement> PsiElement.hasParent(clazz: KClass<T>): Boolean = parentOfT
  */
 fun PsiElement.inMathContext(): Boolean {
     return hasParent(LatexMathContent::class) || inDirectEnvironmentContext(Environment.Context.MATH)
+}
+
+/**
+ * Check if the element is in a comment or not.
+ */
+fun PsiElement.inComment() = inDirectEnvironmentContext(Environment.Context.COMMENT) || when (this) {
+    is PsiComment -> true
+    else -> this is LeafPsiElement && elementType == LatexTypes.COMMAND_TOKEN
 }
 
 /**


### PR DESCRIPTION
# Changes
- All inspections get ignored in `\begin{comment}..\end{comment}` from `comment`.