### PR TITLE
Fixed #199: Only go to line in PDF when the source .tex is opened.

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexMissingDocumentEnvironmentInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexMissingDocumentEnvironmentInspection.kt
@@ -34,7 +34,6 @@ open class LatexMissingDocumentEnvironmentInspection : TexifyInspectionBase() {
             return descriptors
         }
 
-        println("Checks out files: ${file.referencedFileSet().joinToString(", ") { it.name }}")
         for (referencedFile in file.referencedFileSet()) {
             val beginCommands = referencedFile.childrenOfType(LatexBeginCommand::class)
             if (beginCommands.any { it.text == "\\begin{document}" }) {

--- a/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
@@ -46,6 +46,11 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, val runConfi
                 val psiFile = runConfig.mainFile.psiFile(environment.project) ?: return@run
                 val document = psiFile.document() ?: return@run
                 val editor = psiFile.openedEditor() ?: return@run
+
+                if (document != editor.document) {
+                    return@run
+                }
+
                 val line = document.getLineNumber(editor.caretModel.offset) + 1
 
                 runAsync {


### PR DESCRIPTION
# Changes
- Resolves #199.
- I disabled forward search when the cursor is not in the main `.tex`-file.
- Removed debug println.