### PR TITLE
Resolved #220: When in the preamble, don't automatically do the inverse search

### DIFF
--- a/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import nl.rubensten.texifyidea.TeXception
+import nl.rubensten.texifyidea.psi.LatexEnvironment
 import nl.rubensten.texifyidea.util.*
 import org.jetbrains.concurrency.runAsync
 import java.io.File
@@ -51,7 +52,16 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, val runConfi
                     return@run
                 }
 
-                val line = document.getLineNumber(editor.caretModel.offset) + 1
+                // Do not do inverse search when editing the preamble.
+                if (psiFile.isRoot()) {
+                    val element = psiFile.findElementAt(editor.caretOffset()) ?: return@run
+                    val environment = element.parentOfType(LatexEnvironment::class) ?: return@run
+                    if (environment.name()?.text != "document") {
+                        return@run
+                    }
+                }
+
+                val line = document.getLineNumber(editor.caretOffset()) + 1
 
                 runAsync {
                     try {

--- a/src/nl/rubensten/texifyidea/util/GeneralUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/GeneralUtil.kt
@@ -63,7 +63,7 @@ fun runWriteAction(writeAction: () -> Unit) {
 /**
  * Converts an [IntRange] to [TextRange].
  */
-fun IntRange.toTextRange() = TextRange(this.start, this.endInclusive)
+fun IntRange.toTextRange() = TextRange(this.start, this.endInclusive + 1)
 
 /**
  * Converts a [TextRange] to [IntRange].


### PR DESCRIPTION
# Changes
- See title. Fixes #220.
- Achieved it by checking if the caret position is within the document environment.