### PR TITLE
Resolved #209: Words starting with a capital are no longer seen as end of sentence

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexLineBreakInspection.kt
@@ -29,7 +29,7 @@ open class LatexLineBreakInspection : TexifyInspectionBase() {
          * Includes `[^.][^.]` because of abbreviations (at least in Dutch) like `s.v.p.`
          */
         @Language("RegExp")
-        private val SENTENCE_END = Pattern.compile("([^.][^.][.?!;;] +[^%])|(^\\. )")
+        private val SENTENCE_END = Pattern.compile("([^.A-Z][^.A-Z][.?!;;] +[^%])|(^\\. )")
 
         @Language("RegExp")
         private val SENTENCE_SEPERATOR = Pattern.compile("[.?!;;]")


### PR DESCRIPTION
# Changes
- See title. This means that works like `Inc.` or `Mr.` are not valid sentence ends.
- This does mean that sentences ending with names do not get the inspection. I do prefer this over having false positives on the abbreviations.