### PR TITLE
Inspections related to includes

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -517,6 +517,9 @@
         <localInspection language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.bibtex.BibtexDuplicateBibliographystyleInspection"
                          groupName="BibTeX" displayName="Duplicate bibliography style commands"
                          enabledByDefault="true"/>
+        <localInspection language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.bibtex.BibtexDuplicateBibliographyInspection"
+                         groupName="BibTeX" displayName="Same bibliography is included multiple times"
+                         enabledByDefault="true"/>
 
         <!-- Intentions -->
         <intentionAction>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -506,6 +506,9 @@
         <localInspection language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.latex.LatexMakeatletterInspection"
                          groupName="LaTeX" displayName="Discouraged use of \makeatletter in tex sources"
                          enabledByDefault="true"/>
+        <localInspection language="Latex" implementationClass="nl.rubensten.texifyidea.inspections.latex.LatexNoExtensionInspection"
+                         groupName="LaTeX" displayName="File argument should not include the extension"
+                         enabledByDefault="true"/>
 
         <!-- Bibtex inspections -->
         <localInspection language="Bibtex" implementationClass="nl.rubensten.texifyidea.inspections.bibtex.BibtexDuplicateIdInspection"

--- a/resources/inspectionDescriptions/BibtexDuplicateBibliography.html
+++ b/resources/inspectionDescriptions/BibtexDuplicateBibliography.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+A bibliography may only be included by <tt>\bibliography</tt> once.
+<!-- tooltip end -->
+</body>
+</html>

--- a/resources/inspectionDescriptions/LatexNoExtension.html
+++ b/resources/inspectionDescriptions/LatexNoExtension.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Files that are included with <tt>\bibliography</tt> or <tt>\include</tt> should not end with their extension.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -15,7 +15,7 @@ import nl.rubensten.texifyidea.util.commandsInFileSet
 import nl.rubensten.texifyidea.util.requiredParameter
 
 /**
- * @author Ruben Schellekens
+ * @author Sten Wessel
  */
 open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
 

--- a/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -1,0 +1,71 @@
+package nl.rubensten.texifyidea.inspections.bibtex
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import nl.rubensten.texifyidea.index.LatexIncludesIndex
+import nl.rubensten.texifyidea.insight.InsightGroup
+import nl.rubensten.texifyidea.inspections.TexifyInspectionBase
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.commandsInFileSet
+import nl.rubensten.texifyidea.util.requiredParameter
+
+/**
+ * @author Ruben Schellekens
+ */
+open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
+
+    override fun getInspectionGroup() = InsightGroup.LATEX
+
+    override fun getInspectionId() = "DuplicateBibliography"
+
+    // Manual override to match short name in plugin.xml
+    override fun getShortName() = InsightGroup.BIBTEX.prefix + inspectionId
+
+    override fun getDisplayName() = "Same bibliography is included multiple times"
+
+    override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): MutableList<ProblemDescriptor> {
+        val descriptors = descriptorList()
+
+        LatexIncludesIndex.getItemsInFileSet(file)
+            .filter { it.name == "\\bibliography" }
+            .groupBy { it.requiredParameters.getOrNull(0) }
+            .filter { it.key != null && it.value.size > 1 }
+            .flatMap { it.value }
+            .forEach {
+                descriptors.add(manager.createProblemDescriptor(
+                    it, TextRange(0, it.requiredParameter(0)?.length!!).shiftRight(it.commandToken.textLength + 1),
+                    "Bibliography file is included multiple times", ProblemHighlightType.GENERIC_ERROR,
+                    isOntheFly,
+                    RemoveOtherCommandsFix(it.requiredParameter(0)!!)
+                ))
+            }
+
+        return descriptors
+    }
+
+    /**
+     * @author Sten Wessel
+     */
+    class RemoveOtherCommandsFix(private val bibName: String) : LocalQuickFix {
+
+        override fun getFamilyName(): String {
+            return "Remove other includes of $bibName"
+        }
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val command = descriptor.psiElement as LatexCommands
+            val file = command.containingFile
+
+            file.commandsInFileSet()
+                    .filter { it.name == "\\bibliography" && it.requiredParameter(0) == command.requiredParameter(0) && it != command }
+                    .forEach {
+                        it.delete()
+                    }
+        }
+    }
+}

--- a/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -32,18 +32,20 @@ open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
         val descriptors = descriptorList()
 
         LatexIncludesIndex.getItemsInFileSet(file)
-            .filter { it.name == "\\bibliography" }
-            .groupBy { it.requiredParameters.getOrNull(0) }
-            .filter { it.key != null && it.value.size > 1 }
-            .flatMap { it.value }
-            .forEach {
-                descriptors.add(manager.createProblemDescriptor(
-                    it, TextRange(0, it.requiredParameter(0)?.length!!).shiftRight(it.commandToken.textLength + 1),
-                    "Bibliography file is included multiple times", ProblemHighlightType.GENERIC_ERROR,
-                    isOntheFly,
-                    RemoveOtherCommandsFix(it.requiredParameter(0)!!)
-                ))
-            }
+                .filter { it.name == "\\bibliography" }
+                .groupBy { it.requiredParameters.getOrNull(0) }
+                .filter { it.key != null && it.value.size > 1 }
+                .flatMap { it.value }
+                .forEach {
+                    descriptors.add(manager.createProblemDescriptor(
+                            it,
+                            TextRange(0, it.requiredParameter(0)?.length!!).shiftRight(it.commandToken.textLength + 1),
+                            "Bibliography file is included multiple times",
+                            ProblemHighlightType.GENERIC_ERROR,
+                            isOntheFly,
+                            RemoveOtherCommandsFix(it.requiredParameter(0)!!)
+                    ))
+                }
 
         return descriptors
     }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
@@ -19,10 +19,12 @@ import nl.rubensten.texifyidea.util.requiredParameter
  * @author Sten Wessel
  */
 open class LatexNoExtensionInspection : TexifyInspectionBase() {
+
     companion object {
+
         private val NO_EXTENSION_INCLUDES = mapOf(
-            "\\include" to listOf(".tex"),
-            "\\bibliography" to listOf(".bib")
+                "\\include" to listOf(".tex"),
+                "\\bibliography" to listOf(".bib")
         )
     }
 
@@ -36,22 +38,23 @@ open class LatexNoExtensionInspection : TexifyInspectionBase() {
         val descriptors = descriptorList()
 
         LatexCommandsIndex.getItems(file)
-            .filter { it.name in NO_EXTENSION_INCLUDES }
-            .filter { command ->
-                NO_EXTENSION_INCLUDES[command.name]!!.any { command.requiredParameter(0)?.endsWith(it) == true }
-            }
-            .forEach {
-                descriptors.add(manager.createProblemDescriptor(
-                    it, TextRange.allOf(it.requiredParameter(0)!!).shiftRight(it.commandToken.textLength + 1),
-                    "File argument should not include the extension", ProblemHighlightType.GENERIC_ERROR,
-                    isOntheFly,
-                    RemoveExtensionFix
-                ))
-            }
+                .filter { it.name in NO_EXTENSION_INCLUDES }
+                .filter { command ->
+                    NO_EXTENSION_INCLUDES[command.name]!!.any { command.requiredParameter(0)?.endsWith(it) == true }
+                }
+                .forEach {
+                    descriptors.add(manager.createProblemDescriptor(
+                            it,
+                            TextRange.allOf(it.requiredParameter(0)!!).shiftRight(it.commandToken.textLength + 1),
+                            "File argument should not include the extension",
+                            ProblemHighlightType.GENERIC_ERROR,
+                            isOntheFly,
+                            RemoveExtensionFix
+                    ))
+                }
 
         return descriptors
     }
-
 
     /**
      * @author Sten Wessel
@@ -65,15 +68,13 @@ open class LatexNoExtensionInspection : TexifyInspectionBase() {
             val document = command.containingFile.document() ?: return
 
             val replacement = NO_EXTENSION_INCLUDES[command.name]
-                ?.find { command.requiredParameter(0)?.endsWith(it) == true }
-                ?.run { command.requiredParameter(0)?.removeSuffix(this) } ?: return
+                    ?.find { command.requiredParameter(0)?.endsWith(it) == true }
+                    ?.run { command.requiredParameter(0)?.removeSuffix(this) } ?: return
 
             // Exclude the enclosing braces
             val range = command.parameterList.first { it.requiredParam != null }.textRange.shiftRight(1).grown(-2)
 
             document.replaceString(range, replacement)
         }
-
     }
-
 }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
@@ -53,6 +53,9 @@ open class LatexNoExtensionInspection : TexifyInspectionBase() {
     }
 
 
+    /**
+     * @author Sten Wessel
+     */
     object RemoveExtensionFix : LocalQuickFix {
 
         override fun getFamilyName() = "Remove file extension"

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexNoExtensionInspection.kt
@@ -1,0 +1,76 @@
+package nl.rubensten.texifyidea.inspections.latex
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiFile
+import nl.rubensten.texifyidea.index.LatexCommandsIndex
+import nl.rubensten.texifyidea.insight.InsightGroup
+import nl.rubensten.texifyidea.inspections.TexifyInspectionBase
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.document
+import nl.rubensten.texifyidea.util.replaceString
+import nl.rubensten.texifyidea.util.requiredParameter
+
+/**
+ * @author Sten Wessel
+ */
+open class LatexNoExtensionInspection : TexifyInspectionBase() {
+    companion object {
+        private val NO_EXTENSION_INCLUDES = mapOf(
+            "\\include" to listOf(".tex"),
+            "\\bibliography" to listOf(".bib")
+        )
+    }
+
+    override fun getInspectionGroup() = InsightGroup.LATEX
+
+    override fun getInspectionId() = "NoExtension"
+
+    override fun getDisplayName() = "File argument should not include the extension"
+
+    override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): MutableList<ProblemDescriptor> {
+        val descriptors = descriptorList()
+
+        LatexCommandsIndex.getItems(file)
+            .filter { it.name in NO_EXTENSION_INCLUDES }
+            .filter { command ->
+                NO_EXTENSION_INCLUDES[command.name]!!.any { command.requiredParameter(0)?.endsWith(it) == true }
+            }
+            .forEach {
+                descriptors.add(manager.createProblemDescriptor(
+                    it, TextRange.allOf(it.requiredParameter(0)!!).shiftRight(it.commandToken.textLength + 1),
+                    "File argument should not include the extension", ProblemHighlightType.GENERIC_ERROR,
+                    isOntheFly,
+                    RemoveExtensionFix
+                ))
+            }
+
+        return descriptors
+    }
+
+
+    object RemoveExtensionFix : LocalQuickFix {
+
+        override fun getFamilyName() = "Remove file extension"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val command = descriptor.psiElement as LatexCommands
+            val document = command.containingFile.document() ?: return
+
+            val replacement = NO_EXTENSION_INCLUDES[command.name]
+                ?.find { command.requiredParameter(0)?.endsWith(it) == true }
+                ?.run { command.requiredParameter(0)?.removeSuffix(this) } ?: return
+
+            // Exclude the enclosing braces
+            val range = command.parameterList.first { it.requiredParam != null }.textRange.shiftRight(1).grown(-2)
+
+            document.replaceString(range, replacement)
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Inspection that reports when the same bibliography is inserted multiple times
- Inspection that reports when the file extension is used in `\include` or `\bibliography` commands.