### PR TITLE
Resolved #229: import folding breaks at double line breaks and ignore comments

### DIFF
--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -249,6 +249,11 @@ object Magic {
          * Matches newlines.
          */
         @JvmField val newline = RegexPattern.compile("\\n")!!
+
+        /**
+         * Checks if the string is `text`, two newlines, `text.
+         */
+        @JvmField val containsMultipleNewlines = RegexPattern.compile("[^\\n]*\\n\\n+[^\\n]*")!!
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -251,7 +251,7 @@ object Magic {
         @JvmField val newline = RegexPattern.compile("\\n")!!
 
         /**
-         * Checks if the string is `text`, two newlines, `text.
+         * Checks if the string is `text`, two newlines, `text`.
          */
         @JvmField val containsMultipleNewlines = RegexPattern.compile("[^\\n]*\\n\\n+[^\\n]*")!!
     }


### PR DESCRIPTION
# Changes
- Blank lines allow usepackage folding groups to be seperated.
- Comments get ignored by import folding.
- As per default IJ behaviour with Java imports.