### PR TITLE
Check SumatraPDF installation status

### DIFF
--- a/src/nl/rubensten/texifyidea/action/group/SumatraActionGroup.java
+++ b/src/nl/rubensten/texifyidea/action/group/SumatraActionGroup.java
@@ -3,8 +3,8 @@ package nl.rubensten.texifyidea.action.group;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
-import com.intellij.openapi.util.SystemInfo;
 import nl.rubensten.texifyidea.TexifyIcons;
+import nl.rubensten.texifyidea.run.SumatraConversation;
 
 /**
  * @author Ruben Schellekens, Sten Wessel
@@ -13,7 +13,7 @@ public class SumatraActionGroup extends DefaultActionGroup {
 
     @Override
     public boolean canBePerformed(DataContext context) {
-        return SystemInfo.isWindows;
+        return SumatraConversation.isAvailable;
     }
 
     @Override

--- a/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.ui.DialogBuilder
-import com.intellij.openapi.util.SystemInfo
 import nl.rubensten.texifyidea.TexifyIcons
+import nl.rubensten.texifyidea.run.SumatraConversation
 import javax.swing.JLabel
 import javax.swing.SwingConstants
 
@@ -51,6 +51,6 @@ open class ConfigureInverseSearchAction : AnAction(
 
     override fun update(e: AnActionEvent?) {
         val presentation = e?.presentation ?: return
-        presentation.isEnabledAndVisible = SystemInfo.isWindows
+        presentation.isEnabledAndVisible = SumatraConversation.isAvailable
     }
 }

--- a/src/nl/rubensten/texifyidea/action/sumatra/ForwardSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ForwardSearchAction.kt
@@ -3,7 +3,6 @@ package nl.rubensten.texifyidea.action.sumatra
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import nl.rubensten.texifyidea.TeXception
 import nl.rubensten.texifyidea.TexifyIcons
@@ -25,7 +24,7 @@ open class ForwardSearchAction : EditorAction(
 ) {
 
     override fun actionPerformed(file: VirtualFile, project: Project, editor: TextEditor) {
-        if (!SystemInfo.isWindows) {
+        if (!SumatraConversation.isAvailable) {
             return
         }
 
@@ -41,6 +40,6 @@ open class ForwardSearchAction : EditorAction(
 
     override fun update(e: AnActionEvent?) {
         val presentation = e?.presentation ?: return
-        presentation.isEnabledAndVisible = SystemInfo.isWindows
+        presentation.isEnabledAndVisible = SumatraConversation.isAvailable
     }
 }

--- a/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
@@ -60,7 +60,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         }
 
         // Open Sumatra after compilation & execute inverse search.
-        if (SystemInfo.isWindows) {
+        if (SumatraConversation.isAvailable) {
             handler.addProcessListener(OpenSumatraListener(runConfig))
 
             // Inverse search.

--- a/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
+++ b/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
@@ -16,7 +16,6 @@ class OpenSumatraListener(val runConfig: LatexRunConfiguration) : ProcessListene
                 SumatraConversation.openFile(runConfig.outputFilePath, start = true)
             }
             catch (ignored: TeXception) {
-
             }
         }
     }

--- a/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
+++ b/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
@@ -3,7 +3,7 @@ package nl.rubensten.texifyidea.run
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessListener
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.SystemInfo
+import nl.rubensten.texifyidea.TeXception
 
 /**
  * @author Sten Wessel
@@ -11,8 +11,13 @@ import com.intellij.openapi.util.SystemInfo
 class OpenSumatraListener(val runConfig: LatexRunConfiguration) : ProcessListener {
 
     override fun processTerminated(event: ProcessEvent?) {
-        if (event?.exitCode == 0 && SystemInfo.isWindows) {
-            SumatraConversation.openFile(runConfig.outputFilePath, start = true)
+        if (event?.exitCode == 0 && SumatraConversation.isAvailable) {
+            try {
+                SumatraConversation.openFile(runConfig.outputFilePath, start = true)
+            }
+            catch (ignored: TeXception) {
+
+            }
         }
     }
 

--- a/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
+++ b/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
@@ -93,6 +93,7 @@ object SumatraConversation {
 
         val br = process.inputStream.bufferedReader()
         val firstLine = br.readLine() ?: return false
+        br.close()
 
         return !firstLine.startsWith("ERROR:")
     }


### PR DESCRIPTION
On startup, check installation status of SumatraPDF (through registry keys). When SumatraPDF is not installed, disable all `SumatraConversation` actions.

Note: since the installation status is only checked on startup (performance considerations), users must restart TeXiFy when installing SumatraPDF.

Fixes #148.