### PR TITLE
Fix for If-inspection & Added \newif definitions to autocomplete.

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -252,6 +252,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         switch (commands.getName()) {
             case "\\DeclareMathOperator":
             case "\\newcommand":
+            case "\\newif":
                 return getNewCommandName(commands);
             default:
                 return getDefinitionName(commands);

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexNonMatchingIfInspection.kt
@@ -44,6 +44,8 @@ open class LatexNonMatchingIfInspection : TexifyInspectionBase() {
                     ))
                     continue
                 }
+
+                stack.pop()
             }
             else if (Magic.Pattern.ifCommand.matches(name) && cmd.previousCommand()?.name != "\\newif") {
                 stack.push(cmd)

--- a/src/nl/rubensten/texifyidea/util/GeneralUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/GeneralUtil.kt
@@ -2,6 +2,7 @@ package nl.rubensten.texifyidea.util
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.util.TextRange
+import java.util.regex.Pattern
 
 /**
  * Set containing all commands that redefine functionality.
@@ -74,3 +75,8 @@ fun IntRange.toTextRange() = TextRange(this.start, this.endInclusive + 1)
  * Converts a [TextRange] to [IntRange].
  */
 fun TextRange.toIntRange() = startOffset..endOffset
+
+/**
+ * Easy access to [java.util.regex.Matcher.matches].
+ */
+fun Pattern.matches(sequence: CharSequence?) = matcher(sequence).matches()

--- a/src/nl/rubensten/texifyidea/util/GeneralUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/GeneralUtil.kt
@@ -20,7 +20,8 @@ val DEFINITIONS = setOf(
         "\\let",
         "\\def",
         "\\DeclareMathOperator",
-        "\\newenvironment"
+        "\\newenvironment",
+        "\\newif"
 )
 
 /**

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -135,16 +135,6 @@ object Magic {
         )
 
         /**
-         * All if commands.
-         */
-        @JvmField val ifs = setOf(
-                "\\if", "\\ifcat", "\\ifnum", "\\ifdim", "\\ifodd", "\\ifvmode", "\\ifhmode", "\\ifmmode",
-                "\\ifinner", "\\ifvoid", "\\ifhbox", "\\ifvbox", "\\ifx", "\\ifeof", "\\iftrue", "\\iffalse",
-                "\\ifcase", "\\ifdefined", "\\ifcsname", "\\iffontchar", "\\ifincsname", "\\ifpdfprimitive",
-                "\\ifpdfabsnum", "\\ifpdfabsdim", "\\ifpdfprimitive", "\\ifprimitive", "\\ifabsum", "\\ifabsdim"
-        )
-
-        /**
          * All commands that end if.
          */
         @JvmField val endIfs = setOf("\\fi")
@@ -254,6 +244,11 @@ object Magic {
          * Checks if the string is `text`, two newlines, `text`.
          */
         @JvmField val containsMultipleNewlines = RegexPattern.compile("[^\\n]*\\n\\n+[^\\n]*")!!
+
+        /**
+         * Matches a LaTeX command that is the start of an \if-\fi structure.
+         */
+        @JvmField val ifCommand = RegexPattern.compile("\\\\if[a-zA-Z@]*")!!
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -406,14 +406,23 @@ fun LatexCommands.definitionCommand(): LatexCommands? = nextCommand()
 /**
  * Looks for the next command relative to the given command.
  *
- * @param commands
- *          The command to start looking from.
  * @return The next command in the file, or `null` when there is no such command.
  */
 fun LatexCommands.nextCommand(): LatexCommands? {
     val content = parentOfType(LatexContent::class) ?: return null
     val next = content.nextSiblingIgnoreWhitespace() as? LatexContent ?: return null
     return next.firstChildOfType(LatexCommands::class)
+}
+
+/**
+ * Looks for the previous command relative to the given command.
+ *
+ * @return The previous command in the file, or `null` when there is no such command.
+ */
+fun LatexCommands.previousCommand(): LatexCommands? {
+    val content = parentOfType(LatexContent::class) ?: return null
+    val previous = content.previousSiblingIgnoreWhitespace() as? LatexContent ?: return null
+    return previous.firstChildOfType(LatexCommands::class)
 }
 
 /**


### PR DESCRIPTION
# Changes
- Unknown variants of `\if`-commands get recognised by NonMatchingIf inspection.
- Commands defined by `\newif` are now included into the autocomplete.

# Pictures
![image](https://user-images.githubusercontent.com/17410729/33343412-7edfce26-d485-11e7-95ad-e2c91ce6e913.png)
