### PR TITLE
Fixes for SubSupscripts in \label and \bibitem

### DIFF
--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -9,10 +9,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import nl.rubensten.texifyidea.file.LatexFileType
-import nl.rubensten.texifyidea.psi.LatexEnvironmentContent
-import nl.rubensten.texifyidea.psi.LatexMathContent
-import nl.rubensten.texifyidea.psi.LatexNoMathContent
-import nl.rubensten.texifyidea.psi.LatexNormalText
+import nl.rubensten.texifyidea.psi.*
 import nl.rubensten.texifyidea.psi.LatexTypes.*
 import nl.rubensten.texifyidea.util.*
 import java.util.regex.Pattern
@@ -43,6 +40,12 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
         // Find selected element.
         val caret = editor.caretModel
         val element = file.findElementAt(caret.offset - 1) ?: return Result.CONTINUE
+
+        // Check if in \label.
+        val parent = element.parentOfType(LatexCommands::class)
+        when (parent?.name) {
+            "\\label", "\\bibitem" -> return Result.CONTINUE
+        }
 
         // Insert squiggly brackets.
         if (element is LatexNormalText) {

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -169,7 +169,7 @@ abstract class TexifyRegexInspection(
             return false
         }
 
-        return mathMode == element.inMathContext()
+        return mathMode == element.inMathContext() && checkContext(element)
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexGroupedSubSupScriptInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexGroupedSubSupScriptInspection.kt
@@ -1,7 +1,10 @@
 package nl.rubensten.texifyidea.inspections.latex
 
 import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
 import nl.rubensten.texifyidea.inspections.TexifyRegexInspection
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.parentOfType
 import java.util.regex.Pattern
 
 /**
@@ -20,4 +23,13 @@ open class LatexGroupedSubSupScriptInspection : TexifyRegexInspection(
         replacement = { it, _ -> "{${it.group(2)}}" },
         replacementRange = { it.groupRange(2) },
         quickFixName = { "Insert curly braces" }
-)
+) {
+
+    override fun checkContext(element: PsiElement): Boolean {
+        val parent = element.parentOfType(LatexCommands::class)
+        return when (parent?.name) {
+            "\\label", "\\bibitem" -> false
+            else -> super.checkContext(element)
+        }
+    }
+}


### PR DESCRIPTION
# Changes
- Resolves #264: Subscript must be grouped in labels.
- Disabled checking in inspection.
- Disabled auto insertion.