### PR TITLE
TexifyUtil nullpointer issue

### DIFF
--- a/src/nl/rubensten/texifyidea/util/TexifyUtil.java
+++ b/src/nl/rubensten/texifyidea/util/TexifyUtil.java
@@ -653,7 +653,7 @@ public class TexifyUtil {
      * @return Whether the command is known.
      */
     public static boolean isCommandKnown(LatexCommands command) {
-        String commandName = command.getName().substring(1);
+        String commandName = Optional.ofNullable(command.getName()).map(command -> command.substring(1)).orElse("");
         return LatexNoMathCommand.get(commandName) != null || LatexMathCommand.get(commandName) != null;
     }
 


### PR DESCRIPTION
#### Additions
None.

#### Changes
Another fix for a nullpointer issue. Did not find an issue for this one, but encountered it myself. From previous issues we have learned that ```command.getName()``` is nullable, so could use optional here to avoid referencing null.

Here is the stacktrace:
```
null
java.lang.NullPointerException
	at nl.rubensten.texifyidea.util.TexifyUtil.isCommandKnown(TexifyUtil.java:656)
	at nl.rubensten.texifyidea.inspections.latex.LatexCommandAlreadyDefinedInspection.inspectFile(LatexCommandAlreadyDefinedInspection.kt:38)
	at nl.rubensten.texifyidea.inspections.TexifyInspectionBase.checkFile(TexifyInspectionBase.java:57)
	at com.intellij.codeInspection.LocalInspectionTool$1.visitFile(LocalInspectionTool.java:142)
	at com.intellij.extapi.psi.PsiFileBase.accept(PsiFileBase.java:70)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:82)
	at com.intellij.codeInspection.InspectionEngine.createVisitorAndAcceptElements(InspectionEngine.java:70)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.a(LocalInspectionsPass.java:286)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.a(LocalInspectionsPass.java:254)
	at com.intellij.concurrency.ApplierCompleter.c(ApplierCompleter.java:133)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1127)
	at com.intellij.concurrency.ApplierCompleter.a(ApplierCompleter.java:105)
	at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:543)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:488)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:94)
	at com.intellij.concurrency.ApplierCompleter.b(ApplierCompleter.java:116)
	at com.intellij.concurrency.ApplierCompleter.d(ApplierCompleter.java:96)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:143)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:229)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:96)
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)


java.lang.NullPointerException
	at nl.rubensten.texifyidea.util.TexifyUtil.isCommandKnown(TexifyUtil.java:656)
	at nl.rubensten.texifyidea.inspections.latex.LatexCommandAlreadyDefinedInspection.inspectFile(LatexCommandAlreadyDefinedInspection.kt:38)
	at nl.rubensten.texifyidea.inspections.TexifyInspectionBase.checkFile(TexifyInspectionBase.java:57)
	at com.intellij.codeInspection.LocalInspectionTool$1.visitFile(LocalInspectionTool.java:142)
	at com.intellij.extapi.psi.PsiFileBase.accept(PsiFileBase.java:70)
	at com.intellij.codeInspection.InspectionEngine.acceptElements(InspectionEngine.java:82)
	at com.intellij.codeInspection.InspectionEngine.createVisitorAndAcceptElements(InspectionEngine.java:70)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.a(LocalInspectionsPass.java:286)
	at com.intellij.codeInsight.daemon.impl.LocalInspectionsPass.a(LocalInspectionsPass.java:254)
	at com.intellij.concurrency.ApplierCompleter.c(ApplierCompleter.java:133)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1127)
	at com.intellij.concurrency.ApplierCompleter.a(ApplierCompleter.java:105)
	at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:543)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:488)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:94)
	at com.intellij.concurrency.ApplierCompleter.b(ApplierCompleter.java:116)
	at com.intellij.concurrency.ApplierCompleter.d(ApplierCompleter.java:96)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:143)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:229)
	at com.intellij.concurrency.ApplierCompleter.compute(ApplierCompleter.java:96)
	at java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:731)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)


```

#### Backwards incompatible changes
None.