### PR TITLE
Sumatra native library fix

### DIFF
--- a/src/nl/rubensten/texifyidea/action/group/SumatraActionGroup.java
+++ b/src/nl/rubensten/texifyidea/action/group/SumatraActionGroup.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import nl.rubensten.texifyidea.TexifyIcons;
-import nl.rubensten.texifyidea.run.SumatraConversation;
+import nl.rubensten.texifyidea.run.SumatraConversationKt;
 
 /**
  * @author Ruben Schellekens, Sten Wessel
@@ -13,7 +13,7 @@ public class SumatraActionGroup extends DefaultActionGroup {
 
     @Override
     public boolean canBePerformed(DataContext context) {
-        return SumatraConversation.isAvailable;
+        return SumatraConversationKt.isSumatraAvailable();
     }
 
     @Override

--- a/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.ui.DialogBuilder
 import nl.rubensten.texifyidea.TexifyIcons
-import nl.rubensten.texifyidea.run.SumatraConversation
+import nl.rubensten.texifyidea.run.isSumatraAvailable
 import javax.swing.JLabel
 import javax.swing.SwingConstants
 
@@ -51,6 +51,6 @@ open class ConfigureInverseSearchAction : AnAction(
 
     override fun update(e: AnActionEvent?) {
         val presentation = e?.presentation ?: return
-        presentation.isEnabledAndVisible = SumatraConversation.isAvailable
+        presentation.isEnabledAndVisible = isSumatraAvailable
     }
 }

--- a/src/nl/rubensten/texifyidea/action/sumatra/ForwardSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ForwardSearchAction.kt
@@ -8,6 +8,7 @@ import nl.rubensten.texifyidea.TeXception
 import nl.rubensten.texifyidea.TexifyIcons
 import nl.rubensten.texifyidea.action.EditorAction
 import nl.rubensten.texifyidea.run.SumatraConversation
+import nl.rubensten.texifyidea.run.isSumatraAvailable
 
 /**
  * Starts a forward search action in SumatraPDF.
@@ -24,7 +25,7 @@ open class ForwardSearchAction : EditorAction(
 ) {
 
     override fun actionPerformed(file: VirtualFile, project: Project, editor: TextEditor) {
-        if (!SumatraConversation.isAvailable) {
+        if (!isSumatraAvailable) {
             return
         }
 
@@ -40,6 +41,6 @@ open class ForwardSearchAction : EditorAction(
 
     override fun update(e: AnActionEvent?) {
         val presentation = e?.presentation ?: return
-        presentation.isEnabledAndVisible = SumatraConversation.isAvailable
+        presentation.isEnabledAndVisible = isSumatraAvailable
     }
 }

--- a/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
@@ -59,7 +59,7 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         }
 
         // Open Sumatra after compilation & execute inverse search.
-        if (SumatraConversation.isAvailable) {
+        if (isSumatraAvailable) {
             handler.addProcessListener(OpenSumatraListener(runConfig))
 
             // Inverse search.

--- a/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
+++ b/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
@@ -11,7 +11,7 @@ import nl.rubensten.texifyidea.TeXception
 class OpenSumatraListener(val runConfig: LatexRunConfiguration) : ProcessListener {
 
     override fun processTerminated(event: ProcessEvent) {
-        if (event.exitCode == 0 && SumatraConversation.isAvailable) {
+        if (event.exitCode == 0 && isSumatraAvailable) {
             try {
                 SumatraConversation.openFile(runConfig.outputFilePath, start = true)
             }

--- a/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
+++ b/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
@@ -27,7 +27,7 @@ object SumatraConversation {
     private val conversation: DDEClientConversation?
 
     init {
-        if (!SystemInfo.isWindows or !sumatraInstalled()) {
+        if (!SystemInfo.isWindows || !sumatraInstalled()) {
             conversation = null
             isAvailable = false
         }

--- a/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
+++ b/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
@@ -3,6 +3,41 @@ package nl.rubensten.texifyidea.run
 import com.intellij.openapi.util.SystemInfo
 import com.pretty_tools.dde.client.DDEClientConversation
 import nl.rubensten.texifyidea.TeXception
+import nl.rubensten.texifyidea.util.TexifyUtil
+
+/**
+ * Indicates whether SumatraPDF is installed and DDE communication is enabled.
+ *
+ * Is computed once at initialization (for performance), which means that the IDE needs to be restarted when users
+ * install SumatraPDF while running TeXiFy.
+ */
+val isSumatraAvailable: Boolean by lazy {
+    if (!SystemInfo.isWindows || !isSumatraInstalled()) return@lazy false
+
+    // Try if native bindings are available
+    try {
+        DDEClientConversation()
+    }
+    catch (e: NoClassDefFoundError) {
+        TexifyUtil.logf("Native library DLLs could not be found.")
+        return@lazy false
+    }
+
+    true
+}
+
+private fun isSumatraInstalled(): Boolean {
+    // Look up SumatraPDF registry key
+    val process = Runtime.getRuntime().exec(
+            "reg query \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\SumatraPDF.exe\" /ve"
+    )
+
+    val br = process.inputStream.bufferedReader()
+    val firstLine = br.readLine() ?: return false
+    br.close()
+
+    return !firstLine.startsWith("ERROR:")
+}
 
 /**
  * Send commands to SumatraPDF.
@@ -14,33 +49,21 @@ import nl.rubensten.texifyidea.TeXception
  */
 object SumatraConversation {
 
-    /**
-     * Indicates whether SumatraPDF is installed and DDE communication is enabled.
-     *
-     * Is computed once at initialization (for performance), which means that the IDE needs to be restarted when users
-     * install SumatraPDF while running TeXiFy.
-     */
-    @JvmField val isAvailable: Boolean
-
     private val server = "SUMATRA"
     private val topic = "control"
     private val conversation: DDEClientConversation?
 
     init {
-        if (!SystemInfo.isWindows || !sumatraInstalled()) {
+        if (!isSumatraAvailable) {
             conversation = null
-            isAvailable = false
         }
         else {
             try {
                 conversation = DDEClientConversation()
             }
             catch (e: NoClassDefFoundError) {
-                isAvailable = false
                 throw TeXception("Native library DLLs could not be found.", e)
             }
-
-            isAvailable = true
         }
 
     }
@@ -83,19 +106,6 @@ object SumatraConversation {
         finally {
             conversation?.disconnect()
         }
-    }
-
-    private fun sumatraInstalled(): Boolean {
-        // Look up SumatraPDF registry key
-        val process = Runtime.getRuntime().exec(
-                "reg query \"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\SumatraPDF.exe\" /ve"
-        )
-
-        val br = process.inputStream.bufferedReader()
-        val firstLine = br.readLine() ?: return false
-        br.close()
-
-        return !firstLine.startsWith("ERROR:")
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/util/TexifyUtil.java
+++ b/src/nl/rubensten/texifyidea/util/TexifyUtil.java
@@ -653,7 +653,7 @@ public class TexifyUtil {
      * @return Whether the command is known.
      */
     public static boolean isCommandKnown(LatexCommands command) {
-        String commandName = Optional.ofNullable(command.getName()).map(command -> command.substring(1)).orElse("");
+        String commandName = Optional.ofNullable(command.getName()).map(cmd -> cmd.substring(1)).orElse("");
         return LatexNoMathCommand.get(commandName) != null || LatexMathCommand.get(commandName) != null;
     }
 


### PR DESCRIPTION
Fixes issues #432 and #424 (and related).

The check for Sumatra bindings was placed inside the class that depended directly on native DLL libraries, which causes issues on non-Windows systems.

Fixed by placing the `isSumatraAvailable` check outside of the `SumatraConversaion` class.