### PR TITLE
Quickfix to add missing files in include commands

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexFileNotFoundInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexFileNotFoundInspection.kt
@@ -1,6 +1,8 @@
 package nl.rubensten.texifyidea.inspections.latex
 
+import com.intellij.codeInsight.daemon.quickFix.CreateFileFix
 import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.openapi.util.TextRange
@@ -41,22 +43,33 @@ open class LatexFileNotFoundInspection : TexifyInspectionBase() {
                     break
                 }
 
-                arguments[i] as? RequiredFileArgument ?: continue
+                val fileArgument = arguments[i] as? RequiredFileArgument ?: continue
+                val extensions = fileArgument.supportedExtensions
                 val parameter = parameters[i]
                 val fileName = parameter.requiredParam?.firstChildOfType(LatexNormalText::class)?.text ?: continue
                 val root = file.findRootFile()
-                val relative = root.findRelativeFile(fileName)
+                val relative = root.findRelativeFile(fileName, extensions)
 
                 if (relative != null) {
                     continue
                 }
 
+                val fixes: MutableList<LocalQuickFix> = mutableListOf(
+                        CreateFileFix(false, fileName, root.containingDirectory)
+                )
+
+                // Create quick fixes for all extensions if none was supplied in the argument
+                if (extensions.none { fileName.endsWith(".$it") }) {
+                    extensions.forEach { fixes.add(0, CreateFileFix(false, "$fileName.$it", root.containingDirectory)) }
+                }
+
                 descriptors.add(manager.createProblemDescriptor(
                         parameter,
                         TextRange(1, parameter.textLength - 1),
-                        "File not found.",
+                        "File not found",
                         ProblemHighlightType.GENERIC_ERROR,
-                        isOntheFly
+                        isOntheFly,
+                        *fixes.toTypedArray()
                 ))
             }
         }

--- a/src/nl/rubensten/texifyidea/util/FileUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/FileUtil.kt
@@ -105,7 +105,7 @@ fun Project.allFileinclusions(): Map<PsiFile, Set<PsiFile>> {
     for (command in commands) {
         val includedName = TexifyUtil.getIncludedFile(command) ?: continue
         val declaredIn = command.containingFile
-        val referenced = TexifyUtil.getFileRelativeTo(declaredIn, includedName) ?: continue
+        val referenced = TexifyUtil.getFileRelativeTo(declaredIn, includedName, null) ?: continue
 
         val inclusionSet = inclusions[declaredIn] ?: HashSet()
         inclusionSet.add(referenced)
@@ -133,7 +133,7 @@ fun PsiFile.isRoot(): Boolean {
 /**
  * @see [TexifyUtil.getFileRelativeTo]
  */
-fun PsiFile.findRelativeFile(filePath: String) = TexifyUtil.getFileRelativeTo(this, filePath)
+fun PsiFile.findRelativeFile(filePath: String, extensions: Set<String>? = null) = TexifyUtil.getFileRelativeTo(this, filePath, extensions)
 
 /**
  * Looks for all file inclusions in a given file.

--- a/src/nl/rubensten/texifyidea/util/PsiUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiUtil.kt
@@ -299,7 +299,7 @@ fun PsiFile.bibtexIdsInFileSet() = BibtexIdIndex.getIndexedIdsInFileSet(this)
 /**
  * @see TexifyUtil.getFileRelativeTo
  */
-fun PsiFile.fileRelativeTo(path: String): PsiFile? = TexifyUtil.getFileRelativeTo(this, path)
+fun PsiFile.fileRelativeTo(path: String, extensions: Set<String>? = null): PsiFile? = TexifyUtil.getFileRelativeTo(this, path, extensions)
 
 /**
  * @see TexifyUtil.findLabelsInFileSet


### PR DESCRIPTION
Closes #421.

Adds a quickfix to add unresolved files in include commands. Makes use of the (undocumented) `CreateFileFix` in the IntelliJ API. Upon creation, it opens the file automatically.

![](https://user-images.githubusercontent.com/11046840/37110305-d450eb24-223c-11e8-81ef-280d09278957.png)
![](https://user-images.githubusercontent.com/11046840/37110306-d469761c-223c-11e8-9e1c-2887dfdc147c.png)