### PR TITLE
IntelliJ 2018.1 versioning issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ task zip(type: Zip) {
 }
 
 intellij {
-    version '2017.3'
+    version '2018.1'
 }
 
 test {

--- a/src/nl/rubensten/texifyidea/editor/BibtexQuoteInsertHandler.kt
+++ b/src/nl/rubensten/texifyidea/editor/BibtexQuoteInsertHandler.kt
@@ -12,7 +12,7 @@ import nl.rubensten.texifyidea.util.toTextRange
  */
 open class BibtexQuoteInsertHandler : TypedHandlerDelegate() {
 
-    override fun charTyped(char: Char, project: Project?, editor: Editor, file: PsiFile): Result {
+    override fun charTyped(char: Char, project: Project, editor: Editor, file: PsiFile): Result {
         if (file.fileType != BibtexFileType) {
             return super.charTyped(char, project, editor, file)
         }

--- a/src/nl/rubensten/texifyidea/editor/ShiftTracker.kt
+++ b/src/nl/rubensten/texifyidea/editor/ShiftTracker.kt
@@ -48,10 +48,7 @@ object ShiftTracker : KeyListener, TypedHandlerDelegate() {
     fun isShiftPressed(): Boolean = shift
 
     override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
-        if (editor != null) {
-            setup(editor.contentComponent)
-        }
-
+        setup(editor.contentComponent)
         return super.beforeCharTyped(c, project, editor, file, fileType)
     }
 

--- a/src/nl/rubensten/texifyidea/editor/ShiftTracker.kt
+++ b/src/nl/rubensten/texifyidea/editor/ShiftTracker.kt
@@ -47,7 +47,7 @@ object ShiftTracker : KeyListener, TypedHandlerDelegate() {
     @JvmStatic
     fun isShiftPressed(): Boolean = shift
 
-    override fun beforeCharTyped(c: Char, project: Project?, editor: Editor?, file: PsiFile?, fileType: FileType?): Result {
+    override fun beforeCharTyped(c: Char, project: Project, editor: Editor, file: PsiFile, fileType: FileType): Result {
         if (editor != null) {
             setup(editor.contentComponent)
         }

--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -32,7 +32,7 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
         private val insertForbidden = Pattern.compile("^[\\s^_,.;%:$(]$")!!
     }
 
-    override fun charTyped(c: Char, project: Project?, editor: Editor, file: PsiFile): Result {
+    override fun charTyped(c: Char, project: Project, editor: Editor, file: PsiFile): Result {
         if (file.fileType != LatexFileType) {
             return Result.CONTINUE
         }


### PR DESCRIPTION
Opening as discussion, because I see a versioning problem: after installing IntelliJ 2018.1 I could not install TeXiFy build with Gradle under 2017.3, since "plugin is not compatible". The plugin as released to Jetbrains still could be installed.

When changing the build number in Gradle, there were some backwards incompatible changes in the code (see diff of this PR) and  after that it all worked again.

This needs to be sorted out before releasing a gradle build to Jetbrains, since it's not good if the plugin breaks when everyone updates their IDE. 

My guess is that plugins do build against a new IntelliJ version before official release date, and release to Jetbrains for a specific version of IDE only, so users can update to the new version of the plugin once they update their IDE? For example the [markdown plugin](https://plugins.jetbrains.com/plugin/7793-markdown-support) seems to have done this, and it worked quite smooth (just needed extra restart).

That would mean that releases of Jetbrains need to be anticipated to check for backwards incompatible changes?

[edit] I hope that somehow it is possible to build for previous and future versions of intellij just like it was before Gradle?