### PR TITLE
Semi-automatically update Gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,14 @@
 // Include the Gradle plugins which help building everything.
 // Supersedes the use of 'buildscript' block and 'apply plugin:'
 plugins {
-    id 'org.jetbrains.intellij' version '0.2.17'
-    id 'org.jetbrains.kotlin.jvm' version '1.2.31'
+    id 'org.jetbrains.intellij' version '0.3.1'
+    id 'org.jetbrains.kotlin.jvm' version '1.2.41'
+
+    // Plugin which can check for Gradle dependencies, use the help/dependencyUpdates task.
+    id 'com.github.ben-manes.versions' version '0.17.0'
+
+    // Plugin which can update Gradle dependencies, use the help/useLatestVersions task.
+    id 'se.patrikerdes.use-latest-versions' version '0.2.1'
 }
 
 group 'nl.rubensten'
@@ -70,14 +76,14 @@ dependencies {
 
     // Also compile junit 4, just in case
     testCompile("junit:junit:4.12")
-    testRuntime("org.junit.vintage:junit-vintage-engine:4.12.0-M4")
+    testRuntime("org.junit.vintage:junit-vintage-engine:5.2.0")
 
     // Use junit 5 for test cases
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.0.0-M4")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.0.0-M4")
+    testCompile("org.junit.jupiter:junit-jupiter-api:5.2.0")
+    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.2.0")
 
     // Enable use of the JUnitPlatform Runner within the IDE
-    testCompile("org.junit.platform:junit-platform-runner:1.0.0-M4")
+    testCompile("org.junit.platform:junit-platform-runner:1.2.0")
 
     // just in case
     testCompile "org.jetbrains.kotlin:kotlin-test"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Just wanted to show you that there exists a plugin which updates Gradle dependencies automatically (both plugins and module dependencies, but not Gradle itself) when you run it (help/useLatestVersions). Also works for Gradle Kotlin DSL build files. You should try it, it's fun. Not that updating these kind of dependencies is very important, I guess. Ah well.