### PR TITLE
Gradle: always use latest intellij version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ task zip(type: Zip) {
 }
 
 intellij {
-    version '2018.1'
+    version 'LATEST-TRUNK-SNAPSHOT'
 }
 
 test {


### PR DESCRIPTION
I think it would be good to automatically test on the latest (release) version so when builds suddenly fail it might be that intellij has updated with backwards incompatible changes and we will be notified.