### PR TITLE
Remove a4wide from template file

### DIFF
--- a/resources/fileTemplates/internal/LaTeX Source With BibTeX.tex.ft
+++ b/resources/fileTemplates/internal/LaTeX Source With BibTeX.tex.ft
@@ -7,7 +7,7 @@
 \documentclass[11pt]{article}
 
 % Packages
-\usepackage{a4wide}
+\usepackage{amsmath}
 
 % Document
 \begin{document}

--- a/resources/fileTemplates/internal/LaTeX Source.tex.ft
+++ b/resources/fileTemplates/internal/LaTeX Source.tex.ft
@@ -7,7 +7,7 @@
 \documentclass[11pt]{article}
 
 % Packages
-\usepackage{a4wide}
+\usepackage{amsmath}
 
 % Document
 \begin{document}


### PR DESCRIPTION
Using the a4wide package by default creates some unnecessary complications on linux as a4(wide) is pretty hard to install. Besides, some people say it shouldn't be used anyway: https://tex.stackexchange.com/questions/95201/why-should-i-avoid-the-a4-and-aeguill-packages

So I propose to change a4wide into something else like amsmath or whatever you want.