### PR TITLE
Make the insertion of `\item` on enter in itemize-like environments optional

### DIFF
--- a/src/nl/rubensten/texifyidea/editor/InsertEnumerationItem.kt
+++ b/src/nl/rubensten/texifyidea/editor/InsertEnumerationItem.kt
@@ -13,6 +13,7 @@ import nl.rubensten.texifyidea.psi.LatexBeginCommand
 import nl.rubensten.texifyidea.psi.LatexCommands
 import nl.rubensten.texifyidea.psi.LatexEnvironment
 import nl.rubensten.texifyidea.psi.LatexOptionalParam
+import nl.rubensten.texifyidea.settings.TexifySettings
 import nl.rubensten.texifyidea.util.*
 
 /**
@@ -20,7 +21,8 @@ import nl.rubensten.texifyidea.util.*
  */
 class InsertEnumerationItem : EnterHandlerDelegate {
 
-    override fun postProcessEnter(file: PsiFile, editor: Editor, context: DataContext): EnterHandlerDelegate.Result {
+    override fun postProcessEnter(file: PsiFile, editor: Editor,
+                                  context: DataContext): EnterHandlerDelegate.Result {
         ShiftTracker.setup(editor.contentComponent)
         if (file.fileType != LatexFileType) {
             return Result.Continue
@@ -35,7 +37,9 @@ class InsertEnumerationItem : EnterHandlerDelegate {
         return Result.Continue
     }
 
-    override fun preprocessEnter(file: PsiFile, editor: Editor, p2: Ref<Int>, p3: Ref<Int>, context: DataContext, p5: EditorActionHandler?): EnterHandlerDelegate.Result {
+    override fun preprocessEnter(file: PsiFile, editor: Editor, p2: Ref<Int>, p3: Ref<Int>,
+                                 context: DataContext,
+                                 p5: EditorActionHandler?): EnterHandlerDelegate.Result {
         return Result.Continue
     }
 
@@ -73,8 +77,7 @@ class InsertEnumerationItem : EnterHandlerDelegate {
      * @return The last label in the environment, or `null` when there are no labels.
      */
     private fun getLastLabel(environment: PsiElement): LatexCommands? {
-        val commands = environment.childrenOfType(LatexCommands::class)
-                .filter { it.name == "\\item" }
+        val commands = environment.childrenOfType(LatexCommands::class).filter { it.name == "\\item" }
         if (commands.isEmpty()) {
             return null
         }
@@ -108,7 +111,7 @@ class InsertEnumerationItem : EnterHandlerDelegate {
      * @return `true` insertion desired, `false` insertion not desired or element is `null`.
      */
     private fun hasValidContext(element: PsiElement?): Boolean {
-        if (element == null || ShiftTracker.isShiftPressed() || element.inMathContext()) {
+        if (!TexifySettings.getInstance().automaticItemInItemize || element == null || ShiftTracker.isShiftPressed() || element.inMathContext()) {
             return false
         }
 

--- a/src/nl/rubensten/texifyidea/settings/TexifyConfigurable.kt
+++ b/src/nl/rubensten/texifyidea/settings/TexifyConfigurable.kt
@@ -25,7 +25,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
 
             automaticSoftWraps = addCheckbox("Enable soft wraps when opening LaTeX files")
             automaticSecondInlineMathSymbol = addCheckbox("Automatically insert second '$'")
-            automaticItemInItemize = addCheckbox("Automatically insert '\\item' in itemize-like environments")
+            automaticItemInItemize = addCheckbox("Automatically insert '\\item' in itemize-like environments on pressing enter")
         })
     }
 

--- a/src/nl/rubensten/texifyidea/settings/TexifyConfigurable.kt
+++ b/src/nl/rubensten/texifyidea/settings/TexifyConfigurable.kt
@@ -13,6 +13,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
 
     private lateinit var automaticSoftWraps: JCheckBox
     private lateinit var automaticSecondInlineMathSymbol: JCheckBox
+    private lateinit var automaticItemInItemize: JCheckBox
 
     override fun getId() = "TexifyConfigurable"
 
@@ -24,6 +25,7 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
 
             automaticSoftWraps = addCheckbox("Enable soft wraps when opening LaTeX files")
             automaticSecondInlineMathSymbol = addCheckbox("Automatically insert second '$'")
+            automaticItemInItemize = addCheckbox("Automatically insert '\\item' in itemize-like environments")
         })
     }
 
@@ -36,17 +38,20 @@ class TexifyConfigurable(private val settings: TexifySettings) : SearchableConfi
     }
 
     override fun isModified(): Boolean {
-        return automaticSoftWraps.isSelected != settings.automaticSoftWraps ||
-                automaticSecondInlineMathSymbol.isSelected != settings.automaticSecondInlineMathSymbol
+        return automaticSoftWraps.isSelected != settings.automaticSoftWraps
+                || automaticSecondInlineMathSymbol.isSelected != settings.automaticSecondInlineMathSymbol
+                || automaticItemInItemize.isSelected != settings.automaticItemInItemize
     }
 
     override fun apply() {
         settings.automaticSoftWraps = automaticSoftWraps.isSelected
         settings.automaticSecondInlineMathSymbol = automaticSecondInlineMathSymbol.isSelected
+        settings.automaticItemInItemize = automaticItemInItemize.isSelected
     }
 
     override fun reset() {
         automaticSoftWraps.isSelected = settings.automaticSoftWraps
         automaticSecondInlineMathSymbol.isSelected = settings.automaticSecondInlineMathSymbol
+        automaticItemInItemize.isSelected = settings.automaticItemInItemize
     }
 }

--- a/src/nl/rubensten/texifyidea/settings/TexifySettings.kt
+++ b/src/nl/rubensten/texifyidea/settings/TexifySettings.kt
@@ -10,7 +10,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
  *
  * @author Sten Wessel
  */
-@State(name = "TexifySettings", storages = arrayOf(Storage("texifySettings.xml")))
+@State(name = "TexifySettings", storages = [(Storage("texifySettings.xml"))])
 class TexifySettings : PersistentStateComponent<TexifySettings> {
 
     companion object {
@@ -21,6 +21,7 @@ class TexifySettings : PersistentStateComponent<TexifySettings> {
 
     var automaticSoftWraps = false
     var automaticSecondInlineMathSymbol = true
+    var automaticItemInItemize = true
 
     override fun getState() = this
 


### PR DESCRIPTION
It is now possible to disable this feature in the plugin settings.

#### Additions
Checkbox in the plugin settings to enable/disable automatic insertion of `\item` on pressing enter in itemize-like environments. The setting is enabled by default.

#### Changes
The insertion of `\item` on pressing enter in itemize-like environments will be suppressed when the setting is disabled.

#### Backwards incompatible changes
None