### PR TITLE
Improved compile experience

### DIFF
--- a/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
@@ -37,11 +37,6 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
         // Reports exit code to run output window when command is terminated
         ProcessTerminatedListener.attach(handler, environment.project)
 
-        // Generate bibliography run configuration when needed
-        if (!runConfig.isSkipBibtex && runConfig.bibRunConfig == null && mainFile.psiFile(environment.project)?.hasBibliography() == true) {
-            runConfig.generateBibRunConfig()
-        }
-
         runConfig.bibRunConfig?.let {
             if (runConfig.isSkipBibtex) {
                 return@let

--- a/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
+++ b/src/nl/rubensten/texifyidea/run/OpenSumatraListener.kt
@@ -13,7 +13,7 @@ class OpenSumatraListener(val runConfig: LatexRunConfiguration) : ProcessListene
     override fun processTerminated(event: ProcessEvent) {
         if (event.exitCode == 0 && isSumatraAvailable) {
             try {
-                SumatraConversation.openFile(runConfig.outputFilePath, start = true)
+                SumatraConversation.openFile(runConfig.outputFilePath)
             }
             catch (ignored: TeXception) {
             }

--- a/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
+++ b/src/nl/rubensten/texifyidea/run/SumatraConversation.kt
@@ -66,12 +66,12 @@ object SumatraConversation {
 
     }
 
-    fun openFile(pdfFilePath: String, newWindow: Boolean = false, focus: Boolean = false, forceRefresh: Boolean = false, start: Boolean = false) {
-        if (start) {
-            Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -reuse-instance \"$pdfFilePath\"")
-        }
-        else {
+    fun openFile(pdfFilePath: String, newWindow: Boolean = false, focus: Boolean = false, forceRefresh: Boolean = false) {
+        try {
             execute("Open(\"$pdfFilePath\", ${newWindow.bit}, ${focus.bit}, ${forceRefresh.bit})")
+        }
+        catch (e: TeXception) {
+            Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -reuse-instance \"$pdfFilePath\"")
         }
     }
 


### PR DESCRIPTION
#### Additions
None

#### Changes
- When the bibtex run configuration is removed from the latex run config, it will not be automatically added when the document is compiled again. This is to prevent long compilation sequences for large documents that may be undesired. The bibtex run configuration is still generated when the latex run configuration is created from the gutter icon.
- On Windows: SumatraPDF will no longer steal focus from the IDE after compiling the document. This only works when SumatraPDF is already running. When the SumatraPDF process needs to be started, focus will transfer to SumatraPDF (there is no way to reliable prevent this).

#### Backwards incompatible changes
None