### PR TITLE
Fixed #612: Bib entries are not recognized when name clash with tex file exists

### DIFF
--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -136,6 +136,17 @@ object Magic {
         )
 
         /**
+         * Extensions that should only be scanned for the provided include commands.
+         */
+        @JvmField val includeOnlyExtensions = mapOf(
+                "\\include" to setOf("tex"),
+                "\\includeonly" to setOf("tex"),
+                "\\bibliography" to setOf("bib"),
+                "\\RequirePackage" to setOf("sty"),
+                "\\usepackage" to setOf("sty")
+        )
+
+        /**
          * All commands that end if.
          */
         @JvmField val endIfs = setOf("\\fi")

--- a/src/nl/rubensten/texifyidea/util/TexifyUtil.java
+++ b/src/nl/rubensten/texifyidea/util/TexifyUtil.java
@@ -151,7 +151,8 @@ public class TexifyUtil {
             }
 
             PsiFile root = FileUtilKt.findRootFile(file);
-            PsiFile included = getFileRelativeTo(root, fileName, null);
+            Set<String> extensions = Magic.Command.includeOnlyExtensions.get(command.getCommandToken().getText());
+            PsiFile included = getFileRelativeTo(root, fileName, extensions);
             if (included == null) {
                 continue;
             }


### PR DESCRIPTION
Bib files are not recognized as included when a tex file with the same name exists in the directory of the referenced bib file.

This is caused by the fact that getReferencedFiles previously did not take into account which extensions should be scanned for by particular include commands; instead the whole set of include commands (tex, cls, sty and bib) was used. Tex files took precedence over bib files, which made the bib file 'lost'.

#### Additions
None

#### Changes
Added a Magic constant indicating which extensions should be scanned per include command (if any).

#### Backwards incompatible changes
None