### PR TITLE
Add option to disable the out directory

### DIFF
--- a/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
@@ -25,13 +25,10 @@ open class BibtexCommandLineState(
         // The working directory is as specified by the user in the working directory.
         // The fallback (if null or empty) directory is the directory of the main file.
         val bibPath = runConfig.bibWorkingDir?.path
-        val commandLine = if (!(bibPath.equals("") || bibPath == null)) {
+        val commandLine = if (!bibPath.isNullOrBlank()) {
             GeneralCommandLine(command).withWorkDirectory(bibPath)
         }
-        else {
-            GeneralCommandLine(command).withWorkDirectory(runConfig.mainFile?.parent?.path)
-        }
-
+        else GeneralCommandLine(command).withWorkDirectory(runConfig.mainFile?.parent?.path)
 
         val handler: ProcessHandler = KillableProcessHandler(commandLine)
 

--- a/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
@@ -7,7 +7,6 @@ import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.roots.ProjectRootManager
 
 /**
  * @author Sten Wessel
@@ -19,16 +18,20 @@ open class BibtexCommandLineState(
 
     @Throws(ExecutionException::class)
     override fun startProcess(): ProcessHandler {
-        val rootManager = ProjectRootManager.getInstance(environment.project)
-        val fileIndex = rootManager.fileIndex
-        val moduleRoot = fileIndex.getContentRootForFile(runConfig.mainFile!!)
 
         val compiler = runConfig.compiler ?: throw ExecutionException("No valid compiler specified.")
         val command: List<String> = compiler.getCommand(runConfig, environment.project) ?: throw ExecutionException("Compile command could not be created.")
 
         // The working directory is as specified by the user in the working directory.
-        // The fallback (if null) directory is the directory of the main file.
-        val commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.bibWorkingDir?.path ?: runConfig.mainFile?.parent?.path)
+        // The fallback (if null or empty) directory is the directory of the main file.
+        val bibPath = runConfig.bibWorkingDir?.path
+        val commandLine = if (!(bibPath.equals("") || bibPath == null)) {
+            GeneralCommandLine(command).withWorkDirectory(bibPath)
+        }
+        else {
+            GeneralCommandLine(command).withWorkDirectory(runConfig.mainFile?.parent?.path)
+        }
+
 
         val handler: ProcessHandler = KillableProcessHandler(commandLine)
 

--- a/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
@@ -8,8 +8,6 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.roots.ProjectRootManager
-import nl.rubensten.texifyidea.util.PlatformType
-import nl.rubensten.texifyidea.util.getPlatformType
 
 /**
  * @author Sten Wessel
@@ -28,12 +26,9 @@ open class BibtexCommandLineState(
         val compiler = runConfig.compiler ?: throw ExecutionException("No valid compiler specified.")
         val command: List<String> = compiler.getCommand(runConfig, environment.project) ?: throw ExecutionException("Compile command could not be created.")
 
-        // On systems other than Windows the working directory is the directory of the main file.
-        var commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.mainFile?.parent?.path)
-        // Only on Windows (MikTeX) the auxiliary files should be found in the auxiliary directory.
-        if (getPlatformType() == PlatformType.WINDOWS) {
-            commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.bibWorkingDir?.path ?: moduleRoot?.path + "/out")
-        }
+        // The working directory is as specified by the user in the working directory.
+        // The fallback (if null) directory is the directory of the main file.
+        val commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.bibWorkingDir?.path ?: runConfig.mainFile?.parent?.path)
 
         val handler: ProcessHandler = KillableProcessHandler(commandLine)
 

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -82,7 +82,8 @@ public enum LatexCompiler {
         command.add("-synctex=1");
         command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
 
-        if (runConfig.hasOutputDirectories() && (PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
+        // -output-directory also exists on non-Windows systems
+        if (runConfig.hasOutputDirectories()) {
             command.add("-output-directory=" + moduleRoot.getPath() + "/out");
         }
 
@@ -112,10 +113,12 @@ public enum LatexCompiler {
         command.add("-synctex=1");
         command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
 
-        if (runConfig.hasOutputDirectories() && (PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
+        // -output-directory also exists on non-Windows systems
+        if (runConfig.hasOutputDirectories()) {
             command.add("-output-directory=" + moduleRoot.getPath() + "/out");
         }
 
+        // -aux-directory only exists on MikTeX
         if (runConfig.hasAuxiliaryDirectories() &&(PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
             command.add("-aux-directory=" + moduleRoot.getPath() + "/auxil");
         }

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -21,9 +21,12 @@ import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import nl.rubensten.texifyidea.run.LatexCompiler.Format;
+import nl.rubensten.texifyidea.util.PlatformType;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static nl.rubensten.texifyidea.util.PlatformUtilKt.getPlatformType;
 
 /**
  * @author Ruben Schellekens, Sten Wessel
@@ -45,7 +48,8 @@ public class LatexRunConfiguration extends RunConfigurationBase
     private String compilerPath = null;
     private String compilerArguments = null;
     private VirtualFile mainFile;
-    private boolean auxDir = true;
+    // Enable auxDir by default on Windows only
+    private boolean auxDir = getPlatformType() == PlatformType.WINDOWS;
     private boolean outDir = true;
     private Format outputFormat = Format.PDF;
     private String bibRunConfigId = "";
@@ -273,9 +277,12 @@ public class LatexRunConfiguration extends RunConfigurationBase
     public void setDefaultCompiler() {
         setCompiler(LatexCompiler.PDFLATEX);
     }
-    
+
+    /**
+     * Only enabled by default on Windows, because -aux-directory is MikTeX only.
+     */
     public void setDefaultAuxiliaryDirectories() {
-        setAuxiliaryDirectories(true);
+        setAuxiliaryDirectories(getPlatformType() == PlatformType.WINDOWS);
     }
     
     public void setDefaultOutputFormat() {

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -123,7 +123,15 @@ public class LatexRunConfiguration extends RunConfigurationBase
         
         // Read output directories.
         String outDirBoolean = parent.getChildText(OUT_DIR);
-        this.outDir = Boolean.parseBoolean(outDirBoolean);
+        // This is null if the original run configuration did not contain the
+        // option to disable the out directory, which should be enabled by
+        // default.
+        if (outDirBoolean == null) {
+            this.outDir = true;
+        }
+        else {
+            this.outDir = Boolean.parseBoolean(outDirBoolean);
+        }
         
         // Read output format.
         Format format = Format

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -206,6 +206,11 @@ public class LatexRunConfiguration extends RunConfigurationBase
     }
     
     void generateBibRunConfig() {
+        // On non-Windows systems, disable the out/ directory by default for bibtex to work
+        if (getPlatformType() != PlatformType.WINDOWS) {
+            this.outDir = false;
+        }
+
         RunManagerImpl runManager = RunManagerImpl
                 .getInstanceImpl(getProject());
         

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -200,8 +200,7 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
             
             // Output folder
             outDir = new JCheckBox("Separate output files from source "
-                                           + "(disable this when using BiBTeX"
-                                           + " without MiKTeX)");
+                                           + "(disable this when using BiBTeX without MiKTeX)");
             // Enable by default.
             outDir.setSelected(true);
             panel.add(outDir);

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -19,6 +19,7 @@ import com.intellij.ui.TitledSeparator;
 import nl.rubensten.texifyidea.run.LatexCompiler.Format;
 import nl.rubensten.texifyidea.util.PlatformType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.event.ItemEvent;
@@ -36,7 +37,10 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
     private TextFieldWithBrowseButton compilerPath;
     private LabeledComponent<RawCommandLineEditor> compilerArguments;
     private LabeledComponent<ComponentWithBrowseButton> mainFile;
+    // The following options may or may not exist.
+    @Nullable
     private JCheckBox auxDir;
+    @Nullable
     private JCheckBox outDir;
     private LabeledComponent<ComboBox> outputFormat;
     private BibliographyPanel bibliographyPanel;
@@ -67,10 +71,14 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
         txtFile.setText(path);
 
         // Reset seperate auxiliary files.
-        auxDir.setSelected(runConfiguration.hasAuxiliaryDirectories());
-        
+        if (auxDir != null) {
+            auxDir.setSelected(runConfiguration.hasAuxiliaryDirectories());
+        }
+
         // Reset seperate output files.
-        outDir.setSelected(runConfiguration.hasOutputDirectories());
+        if (outDir != null) {
+            outDir.setSelected(runConfiguration.hasOutputDirectories());
+        }
 
         // Reset output format.
         outputFormat.getComponent().setSelectedItem(runConfiguration.getOutputFormat());
@@ -100,12 +108,16 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
         String filePath = txtFile.getText();
         runConfiguration.setMainFile(filePath);
 
-        // Apply auxiliary files.
-        boolean auxDirectories = auxDir.isSelected();
-        runConfiguration.setAuxiliaryDirectories(auxDirectories);
-        
-        boolean outDirectories = outDir.isSelected();
-        runConfiguration.setOutputDirectories(outDirectories);
+        // Apply auxiliary files, only if the option exists.
+        if (auxDir != null) {
+            boolean auxDirectories = auxDir.isSelected();
+            runConfiguration.setAuxiliaryDirectories(auxDirectories);
+        }
+
+        if (outDir != null) {
+            boolean outDirectories = outDir.isSelected();
+            runConfiguration.setOutputDirectories(outDirectories);
+        }
 
         // Apply output format.
         Format format = (Format)outputFormat.getComponent().getSelectedItem();

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -184,13 +184,15 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
             // Only enable by default on Windows.
             auxDir.setSelected(getPlatformType() == PlatformType.WINDOWS);
             panel.add(auxDir);
+        }
             
             // Output folder
-            outDir = new JCheckBox("Separate output files from source");
-            // Only enable by default on Windows.
-            outDir.setSelected(getPlatformType() == PlatformType.WINDOWS);
+            outDir = new JCheckBox("Separate output files from source "
+                                           + "(disable this when using BiBTeX"
+                                           + " without MiKTeX)");
+            // Enable by default.
+            outDir.setSelected(true);
             panel.add(outDir);
-        }
 
         // Output format.
         ComboBox<Format> cboxFormat = new ComboBox<>(Format.values());


### PR DESCRIPTION
Continuation of PR #645, solves issue #728.

#### Additions
- Add the option to disable the out/ directory (on Windows/MiKTeX).

#### Changes
- Fix bibtex working directory when auxil/ is not used (on Windows/MiKTeX).
- Make auxil/ and out/ options invisible for non-windows systems (at the moment they just don't do anything on non-windows systems).
- Make the auxil path invisible in the BiBTeX run configuration, as this was overwritten by the settings in the LaTeX run configuration.

#### To test
- [x] Not Windows systems (I can't actually test this myself): see that in the LaTeX run configuration, the Options section is not present. This includes the options to disable the aux and out directories.
- [x] Compile a simple file that includes a `.bib` (e.g. the one below without the index stuff) and disable the aux or out folder, or both.
- [x] A good test is disabling both the aux and out folders and compiling the following tex file, which includes an index and bibliography:
```
\documentclass{article}

\usepackage{amsmath}
\usepackage{imakeidx}

\makeindex

\begin{document}

    Please look at~\cite{golub}.
    This \index{this} will appear in the index.

    \printindex

    \newpage
    \bibliography{main}
    \bibliographystyle{plain}

\end{document}
```
where the `main.bib` file is
```
@Book{golub,
    title     = {Matrix {C}omputations},
    publisher = {JHU Press},
    year      = {2012},
    author    = {Golub, Gene H and Van Loan, Charles F},
    edition   = {4}
}
```
