### PR TITLE
Add lualatex option to compilers

### DIFF
--- a/src/nl/rubensten/texifyidea/lang/DefaultEnvironment.kt
+++ b/src/nl/rubensten/texifyidea/lang/DefaultEnvironment.kt
@@ -80,7 +80,10 @@ enum class DefaultEnvironment(
     CASES(environmentName = "cases", context = Context.MATH, dependency = Package.AMSMATH),
 
     // comment
-    COMMENT(environmentName = "comment", context = Context.COMMENT, dependency = Package.COMMENT);
+    COMMENT(environmentName = "comment", context = Context.COMMENT, dependency = Package.COMMENT),
+
+    // lualatex
+    LUACODE(environmentName = "luacode", dependency = Package.LUACODE);
 
     companion object {
 

--- a/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.kt
+++ b/src/nl/rubensten/texifyidea/lang/LatexNoMathCommand.kt
@@ -49,6 +49,7 @@ enum class LatexNoMathCommand(
     DATE("date", "text".asRequired(Type.TEXT)),
     DECLARE_MATH_OPERATOR("DeclareMathOperator", "command".asRequired(), "operator".asRequired(Type.TEXT)),
     DEF("def"),
+    DIRECTLUA("directlua", "luacode".asRequired()),
     DOCUMENTCLASS("documentclass", "options".asOptional(), "class".asRequired()),
     DOTFILL("dotfill"),
     EM("em"),

--- a/src/nl/rubensten/texifyidea/lang/Package.kt
+++ b/src/nl/rubensten/texifyidea/lang/Package.kt
@@ -25,6 +25,7 @@ open class Package @JvmOverloads constructor(
         @JvmField val LATEXSYMB = Package("latexsymb")
         @JvmField val COMMENT = Package("comment")
         @JvmField val BIBLATEX = Package("biblatex", "backend=bibtex")
+        @JvmField val LUACODE = Package("luacode")
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
@@ -8,6 +8,8 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.roots.ProjectRootManager
+import nl.rubensten.texifyidea.util.PlatformType
+import nl.rubensten.texifyidea.util.getPlatformType
 
 /**
  * @author Sten Wessel
@@ -29,7 +31,7 @@ open class BibtexCommandLineState(
         // On systems other than Windows the working directory is the directory of the main file.
         var commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.mainFile?.parent?.path)
         // Only on Windows (MikTeX) the auxiliary files should be found in the auxiliary directory.
-        if (System.getProperty("os.name").contains("Windows")) {
+        if (getPlatformType() == PlatformType.WINDOWS) {
             commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.bibWorkingDir?.path ?: moduleRoot?.path + "/out")
         }
 

--- a/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexCommandLineState.kt
@@ -7,6 +7,7 @@ import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.roots.ProjectRootManager
 
 /**
  * @author Sten Wessel
@@ -18,10 +19,20 @@ open class BibtexCommandLineState(
 
     @Throws(ExecutionException::class)
     override fun startProcess(): ProcessHandler {
+        val rootManager = ProjectRootManager.getInstance(environment.project)
+        val fileIndex = rootManager.fileIndex
+        val moduleRoot = fileIndex.getContentRootForFile(runConfig.mainFile!!)
+
         val compiler = runConfig.compiler ?: throw ExecutionException("No valid compiler specified.")
         val command: List<String> = compiler.getCommand(runConfig, environment.project) ?: throw ExecutionException("Compile command could not be created.")
 
-        val commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.auxDir?.path ?: runConfig.mainFile?.parent?.path)
+        // On systems other than Windows the working directory is the directory of the main file.
+        var commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.mainFile?.parent?.path)
+        // Only on Windows (MikTeX) the auxiliary files should be found in the auxiliary directory.
+        if (System.getProperty("os.name").contains("Windows")) {
+            commandLine = GeneralCommandLine(command).withWorkDirectory(runConfig.bibWorkingDir?.path ?: moduleRoot?.path + "/out")
+        }
+
         val handler: ProcessHandler = KillableProcessHandler(commandLine)
 
         // Reports exit code to run output window when command is terminated

--- a/src/nl/rubensten/texifyidea/run/BibtexRunConfiguration.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexRunConfiguration.kt
@@ -38,7 +38,7 @@ class BibtexRunConfiguration(
         }
 
     var mainFile: VirtualFile? = null
-    var auxDir: VirtualFile? = null
+    var bibWorkingDir: VirtualFile? = null
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> = BibtexSettingsEditor(project)
 
@@ -83,7 +83,7 @@ class BibtexRunConfiguration(
         }
 
         val auxDirPath = parent.getChildText(AUX_DIR)
-        auxDir = if (auxDirPath != null) {
+        bibWorkingDir = if (auxDirPath != null) {
             LocalFileSystem.getInstance().findFileByPath(auxDirPath)
         } else {
             null
@@ -100,7 +100,7 @@ class BibtexRunConfiguration(
         parent.addContent(Element(COMPILER_PATH).apply { text = compilerPath ?: "" })
         parent.addContent(Element(COMPILER_ARGUMENTS).apply { text = compilerArguments ?: "" })
         parent.addContent(Element(MAIN_FILE).apply { text = mainFile?.path ?: "" })
-        parent.addContent(Element(AUX_DIR).apply { text = auxDir?.path ?: "" })
+        parent.addContent(Element(AUX_DIR).apply { text = bibWorkingDir?.path ?: "" })
     }
 
     override fun isGeneratedName() = name == suggestedName()

--- a/src/nl/rubensten/texifyidea/run/BibtexSettingsEditor.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexSettingsEditor.kt
@@ -26,11 +26,13 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
     private lateinit var compilerPath: TextFieldWithBrowseButton
     private lateinit var compilerArguments: LabeledComponent<RawCommandLineEditor>
     private lateinit var mainFile: LabeledComponent<TextFieldWithBrowseButton>
-    private lateinit var auxFile: LabeledComponent<TextFieldWithBrowseButton>
+    // Keep track of the the working directory for bibtex, i.e., where bibtex
+    // should find the files it needs. User sets this in latex run configuration.
+    private lateinit var bibWorkingDir: String
 
     override fun createEditor(): JComponent {
-        createUIComponents();
-        return panel;
+        createUIComponents()
+        return panel
     }
 
     override fun resetEditorFrom(runConfig: BibtexRunConfiguration) {
@@ -39,7 +41,7 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
         compilerArguments.component.text = runConfig.compilerArguments ?: ""
         enableCompilerPath.isSelected = runConfig.compilerPath != null
         mainFile.component.text = runConfig.mainFile?.path ?: ""
-        auxFile.component.text = runConfig.auxDir?.path ?: ""
+        bibWorkingDir = runConfig.bibWorkingDir?.path ?: ""
     }
 
     override fun applyEditorTo(runConfig: BibtexRunConfiguration) {
@@ -47,7 +49,7 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
         runConfig.compilerPath = if (enableCompilerPath.isSelected) compilerPath.text else null
         runConfig.compilerArguments = compilerArguments.component.text
         runConfig.mainFile = LocalFileSystem.getInstance().findFileByPath(mainFile.component.text)
-        runConfig.auxDir = LocalFileSystem.getInstance().findFileByPath(auxFile.component.text)
+        runConfig.bibWorkingDir = LocalFileSystem.getInstance().findFileByPath(bibWorkingDir)
     }
 
     private fun createUIComponents() {
@@ -103,16 +105,6 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
             ) }
             mainFile = LabeledComponent.create(mainFileField, "Main file that includes bibliography")
             add(mainFile)
-
-            // Aux file
-            val auxFileField = TextFieldWithBrowseButton().apply { addBrowseFolderListener(
-                TextBrowseFolderListener(
-                    FileChooserDescriptor(false, true, false, false, false, false)
-                        .withRoots(*ProjectRootManager.getInstance(project).contentRootsFromAllModules)
-                )
-            ) }
-            auxFile = LabeledComponent.create(auxFileField, "Auxiliary files directory (keep empty when location is the same as for the main file)")
-            add(auxFile)
         }
     }
 }

--- a/src/nl/rubensten/texifyidea/run/BibtexSettingsEditor.kt
+++ b/src/nl/rubensten/texifyidea/run/BibtexSettingsEditor.kt
@@ -26,8 +26,8 @@ class BibtexSettingsEditor(private val project: Project) : SettingsEditor<Bibtex
     private lateinit var compilerPath: TextFieldWithBrowseButton
     private lateinit var compilerArguments: LabeledComponent<RawCommandLineEditor>
     private lateinit var mainFile: LabeledComponent<TextFieldWithBrowseButton>
-    // Keep track of the the working directory for bibtex, i.e., where bibtex
-    // should find the files it needs. User sets this in latex run configuration.
+    /** Keep track of the the working directory for bibtex, i.e., where bibtex should find the files it needs.
+     * User sets this in latex run configuration. */
     private lateinit var bibWorkingDir: String
 
     override fun createEditor(): JComponent {

--- a/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCommandLineState.kt
@@ -42,10 +42,21 @@ open class LatexCommandLineState(environment: ExecutionEnvironment, private val 
                 return@let
             }
 
-            // Change configuration to match the latex settings
+            // Pass necessary latex run configurations settings to the bibtex run configuration.
             (it.configuration as? BibtexRunConfiguration)?.apply {
                 this.mainFile = mainFile
-                this.auxDir = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile)?.findChild("auxil")
+                // Check if the aux, out, or src folder should be used as bib working dir.
+                when {
+                    runConfig.hasAuxiliaryDirectories() -> {
+                        this.bibWorkingDir = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile)?.findChild("auxil")
+                    }
+                    runConfig.hasOutputDirectories() -> {
+                        this.bibWorkingDir = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile)?.findChild("out")
+                    }
+                    else -> {
+                        this.bibWorkingDir = ProjectRootManager.getInstance(project).fileIndex.getContentRootForFile(mainFile)?.findChild(mainFile.parent.name)
+                    }
+                }
             }
 
             handler.addProcessListener(RunBibtexListener(it, runConfig, environment))

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -49,15 +49,21 @@ public enum LatexCompiler {
             command.add("-interaction=nonstopmode");
             command.add("-synctex=1");
             command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
-            command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+            
+            if (runConfig.hasOutputDirectories() && System.getProperty("os.name").contains("Windows")) {
+                command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+            }
 
-            if (runConfig.hasAuxiliaryDirectories()) {
+            if (runConfig.hasAuxiliaryDirectories() && System.getProperty("os.name").contains("Windows")) {
                 command.add("-aux-directory=" + moduleRoot.getPath() + "/auxil");
             }
 
-            for (VirtualFile root : moduleRoots) {
-                command.add("-include-directory=" + root.getPath());
+            if (System.getProperty("os.name").contains("Windows")) {
+                for (VirtualFile root : moduleRoots) {
+                    command.add("-include-directory=" + root.getPath());
+                }
             }
+
         } else if (this == LUALATEX) {
             if (runConfig.getCompilerPath() != null) {
                 command.add(runConfig.getCompilerPath());

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -15,7 +15,8 @@ import java.util.List;
  */
 public enum LatexCompiler {
 
-    PDFLATEX("pdfLaTeX", "pdflatex");
+    PDFLATEX("pdfLaTeX", "pdflatex"),
+    LUALATEX("LuaLaTeX", "lualatex");
 
     private String displayName;
     private String executableName;
@@ -57,6 +58,21 @@ public enum LatexCompiler {
             for (VirtualFile root : moduleRoots) {
                 command.add("-include-directory=" + root.getPath());
             }
+        } else if (this == LUALATEX) {
+            if (runConfig.getCompilerPath() != null) {
+                command.add(runConfig.getCompilerPath());
+            } else {
+                command.add("lualatex");
+            }
+
+            // Some commands are the same as for pdflatex
+            command.add("-file-line-error");
+            command.add("-interaction=nonstopmode");
+            command.add("-synctex=1");
+            command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
+            command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+
+            // But lualatex has no -aux-directory
         }
 
         // Custom compiler arguments specified by the user

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -4,6 +4,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
+import nl.rubensten.texifyidea.util.PlatformType;
+import nl.rubensten.texifyidea.util.PlatformUtilKt;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -80,7 +82,7 @@ public enum LatexCompiler {
         command.add("-synctex=1");
         command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
 
-        if (runConfig.hasOutputDirectories() && getPlatform() == Platform.WINDOWS) {
+        if (runConfig.hasOutputDirectories() && (PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
             command.add("-output-directory=" + moduleRoot.getPath() + "/out");
         }
 
@@ -110,15 +112,15 @@ public enum LatexCompiler {
         command.add("-synctex=1");
         command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
 
-        if (runConfig.hasOutputDirectories() && getPlatform() == Platform.WINDOWS) {
+        if (runConfig.hasOutputDirectories() && (PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
             command.add("-output-directory=" + moduleRoot.getPath() + "/out");
         }
 
-        if (runConfig.hasAuxiliaryDirectories() && getPlatform() == Platform.WINDOWS) {
+        if (runConfig.hasAuxiliaryDirectories() &&(PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
             command.add("-aux-directory=" + moduleRoot.getPath() + "/auxil");
         }
 
-        if (getPlatform() == Platform.WINDOWS) {
+        if ((PlatformUtilKt.getPlatformType() == PlatformType.WINDOWS)) {
             for (VirtualFile root : moduleRoots) {
                 command.add("-include-directory=" + root.getPath());
             }

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -40,48 +40,10 @@ public enum LatexCompiler {
         }
 
         if (this == PDFLATEX) {
-            if (runConfig.getCompilerPath() != null) {
-                command.add(runConfig.getCompilerPath());
-            } else {
-                command.add("pdflatex");
-            }
-            command.add("-file-line-error");
-            command.add("-interaction=nonstopmode");
-            command.add("-synctex=1");
-            command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
-
-            if (runConfig.hasOutputDirectories() && System.getProperty("os.name").contains("Windows")) {
-                command.add("-output-directory=" + moduleRoot.getPath() + "/out");
-            }
-
-            if (runConfig.hasAuxiliaryDirectories() && System.getProperty("os.name").contains("Windows")) {
-                command.add("-aux-directory=" + moduleRoot.getPath() + "/auxil");
-            }
-
-            if (System.getProperty("os.name").contains("Windows")) {
-                for (VirtualFile root : moduleRoots) {
-                    command.add("-include-directory=" + root.getPath());
-                }
-            }
-
-        } else if (this == LUALATEX) {
-            if (runConfig.getCompilerPath() != null) {
-                command.add(runConfig.getCompilerPath());
-            } else {
-                command.add("lualatex");
-            }
-
-            // Some commands are the same as for pdflatex
-            command.add("-file-line-error");
-            command.add("-interaction=nonstopmode");
-            command.add("-synctex=1");
-            command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
-
-            if (runConfig.hasOutputDirectories() && System.getProperty("os.name").contains("Windows")) {
-                command.add("-output-directory=" + moduleRoot.getPath() + "/out");
-            }
-
-            // But lualatex has no -aux-directory
+            command = createPdflatexCommand(runConfig, moduleRoot, moduleRoots);
+        }
+        else if (this == LUALATEX) {
+            command = createLualatexCommand(runConfig, moduleRoot);
         }
 
         // Custom compiler arguments specified by the user
@@ -91,6 +53,76 @@ public enum LatexCompiler {
         }
 
         command.add(mainFile.getName());
+
+        return command;
+    }
+
+    /**
+     * Create the command to execute lualatex.
+     *
+     * @param runConfig LaTeX run configuration which initiated the action of creating this command.
+     * @param moduleRoot Module root.
+     *
+     * @return The command to be executed.
+     */
+    private List<String> createLualatexCommand(LatexRunConfiguration runConfig, VirtualFile moduleRoot) {
+        List<String> command = new ArrayList<>();
+
+        if (runConfig.getCompilerPath() != null) {
+            command.add(runConfig.getCompilerPath());
+        } else {
+            command.add("lualatex");
+        }
+
+        // Some commands are the same as for pdflatex
+        command.add("-file-line-error");
+        command.add("-interaction=nonstopmode");
+        command.add("-synctex=1");
+        command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
+
+        if (runConfig.hasOutputDirectories() && getPlatform() == Platform.WINDOWS) {
+            command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+        }
+
+        // Note that lualatex has no -aux-directory
+        return command;
+    }
+
+    /**
+     * Create the command to execute pdflatex.
+     *
+     * @param runConfig LaTeX run configuration which initiated the action of creating this command.
+     * @param moduleRoot Module root.
+     * @param moduleRoots List of source roots.
+     *
+     * @return The command to be executed.
+     */
+    private List<String> createPdflatexCommand(LatexRunConfiguration runConfig, VirtualFile moduleRoot, VirtualFile[] moduleRoots) {
+        List<String> command = new ArrayList<>();
+
+        if (runConfig.getCompilerPath() != null) {
+            command.add(runConfig.getCompilerPath());
+        } else {
+            command.add("pdflatex");
+        }
+        command.add("-file-line-error");
+        command.add("-interaction=nonstopmode");
+        command.add("-synctex=1");
+        command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
+
+        if (runConfig.hasOutputDirectories() && getPlatform() == Platform.WINDOWS) {
+            command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+        }
+
+        if (runConfig.hasAuxiliaryDirectories() && getPlatform() == Platform.WINDOWS) {
+            command.add("-aux-directory=" + moduleRoot.getPath() + "/auxil");
+        }
+
+        if (getPlatform() == Platform.WINDOWS) {
+            for (VirtualFile root : moduleRoots) {
+                command.add("-include-directory=" + root.getPath());
+            }
+        }
 
         return command;
     }

--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.java
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.java
@@ -49,7 +49,7 @@ public enum LatexCompiler {
             command.add("-interaction=nonstopmode");
             command.add("-synctex=1");
             command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
-            
+
             if (runConfig.hasOutputDirectories() && System.getProperty("os.name").contains("Windows")) {
                 command.add("-output-directory=" + moduleRoot.getPath() + "/out");
             }
@@ -76,7 +76,10 @@ public enum LatexCompiler {
             command.add("-interaction=nonstopmode");
             command.add("-synctex=1");
             command.add("-output-format=" + runConfig.getOutputFormat().name().toLowerCase());
-            command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+
+            if (runConfig.hasOutputDirectories() && System.getProperty("os.name").contains("Windows")) {
+                command.add("-output-directory=" + moduleRoot.getPath() + "/out");
+            }
 
             // But lualatex has no -aux-directory
         }

--- a/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
+++ b/src/nl/rubensten/texifyidea/run/LatexRunConfiguration.java
@@ -28,103 +28,119 @@ import org.jetbrains.annotations.Nullable;
 /**
  * @author Ruben Schellekens, Sten Wessel
  */
-public class LatexRunConfiguration extends RunConfigurationBase implements LocatableConfiguration {
-
+public class LatexRunConfiguration extends RunConfigurationBase
+        implements LocatableConfiguration {
+    
     private static final String TEXIFY_PARENT = "texify";
     private static final String COMPILER = "compiler";
     private static final String COMPILER_PATH = "compiler-path";
     private static final String COMPILER_ARGUMENTS = "compiler-arguments";
     private static final String MAIN_FILE = "main-file";
     private static final String AUX_DIR = "aux-dir";
+    private static final String OUT_DIR = "out-dir";
     private static final String OUTPUT_FORMAT = "output-format";
     private static final String BIB_RUN_CONFIG = "bib-run-config";
-
+    
     private LatexCompiler compiler;
     private String compilerPath = null;
     private String compilerArguments = null;
     private VirtualFile mainFile;
     private boolean auxDir = true;
+    private boolean outDir = true;
     private Format outputFormat = Format.PDF;
     private String bibRunConfigId = "";
     private boolean skipBibtex = false;
-
-    protected LatexRunConfiguration(Project project, ConfigurationFactory factory, String name) {
+    
+    protected LatexRunConfiguration(Project project,
+                                    ConfigurationFactory factory, String name) {
         super(project, factory, name);
     }
-
+    
     @NotNull
     @Override
     public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
         return new LatexSettingsEditor(getProject());
     }
-
+    
     @Override
     public void checkConfiguration() throws RuntimeConfigurationException {
         if (compiler == null || mainFile == null || outputFormat == null) {
-            throw new RuntimeConfigurationError("Run configuration is invalid.");
+            throw new RuntimeConfigurationError(
+                    "Run configuration is invalid.");
         }
     }
-
+    
     @Nullable
     @Override
-    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
-        RegexpFilter filter = new RegexpFilter(environment.getProject(), "^$FILE_PATH$:$LINE$");
-
-        LatexCommandLineState state = new LatexCommandLineState(environment, this);
+    public RunProfileState getState(@NotNull Executor executor,
+                                    @NotNull ExecutionEnvironment environment)
+            throws ExecutionException {
+        RegexpFilter filter = new RegexpFilter(environment.getProject(),
+                                               "^$FILE_PATH$:$LINE$");
+        
+        LatexCommandLineState state = new LatexCommandLineState(environment,
+                                                                this);
         state.addConsoleFilters(filter);
         return state;
     }
-
+    
     @Override
     public void readExternal(Element element) throws InvalidDataException {
         super.readExternal(element);
-
+        
         Element parent = element.getChild(TEXIFY_PARENT);
         if (parent == null) {
             return;
         }
-
+        
         // Read compiler.
         String compilerName = parent.getChildText(COMPILER);
         try {
             this.compiler = LatexCompiler.valueOf(compilerName);
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             this.compiler = null;
         }
-
+        
         // Read compiler custom path.
         String compilerPathRead = parent.getChildText(COMPILER_PATH);
-        this.compilerPath = (compilerPathRead == null || compilerPathRead.isEmpty()) ? null : compilerPathRead;
-
+        this.compilerPath =
+                (compilerPathRead == null || compilerPathRead.isEmpty()) ?
+                null : compilerPathRead;
+        
         // Read compiler arguments.
         String compilerArgumentsRead = parent.getChildText(COMPILER_ARGUMENTS);
-        setCompilerArguments("".equals(compilerArgumentsRead) ? null : compilerArgumentsRead);
-
+        setCompilerArguments("".equals(compilerArgumentsRead) ? null :
+                             compilerArgumentsRead);
+        
         // Read main file.
         LocalFileSystem fileSystem = LocalFileSystem.getInstance();
         String filePath = parent.getChildText(MAIN_FILE);
         this.mainFile = fileSystem.findFileByPath(filePath);
-
+        
         // Read auxiliary directories.
         String auxDirBoolean = parent.getChildText(AUX_DIR);
         this.auxDir = Boolean.parseBoolean(auxDirBoolean);
-
+        
+        // Read output directories.
+        String outDirBoolean = parent.getChildText(OUT_DIR);
+        this.outDir = Boolean.parseBoolean(outDirBoolean);
+        
         // Read output format.
-        Format format = Format.byNameIgnoreCase(parent.getChildText(OUTPUT_FORMAT));
+        Format format = Format
+                .byNameIgnoreCase(parent.getChildText(OUTPUT_FORMAT));
         this.outputFormat = format == null ? Format.PDF : format;
-
+        
         // Read bibliography run configuration
         String bibRunConfigElt = parent.getChildText(BIB_RUN_CONFIG);
         this.bibRunConfigId = bibRunConfigElt == null ? "" : bibRunConfigElt;
     }
-
+    
     @Override
     public void writeExternal(Element element) throws WriteExternalException {
         super.writeExternal(element);
-
+        
         Element parent = element.getChild(TEXIFY_PARENT);
-
+        
         // Create a new parent when there is no parent present.
         if (parent == null) {
             parent = new Element(TEXIFY_PARENT);
@@ -134,74 +150,81 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
         else {
             parent.removeContent();
         }
-
+        
         // Write compiler.
         final Element compilerElt = new Element(COMPILER);
         compilerElt.setText(compiler == null ? "" : compiler.name());
         parent.addContent(compilerElt);
-
+        
         // Write compiler path.
         final Element compilerPathElt = new Element(COMPILER_PATH);
         compilerPathElt.setText(compilerPath == null ? "" : compilerPath);
         parent.addContent(compilerPathElt);
-
+        
         // Write compiler arguments
         final Element compilerArgsElt = new Element(COMPILER_ARGUMENTS);
-        compilerArgsElt.setText(compilerArguments == null ? "" : compilerArguments);
+        compilerArgsElt
+                .setText(compilerArguments == null ? "" : compilerArguments);
         parent.addContent(compilerArgsElt);
-
+        
         // Write main file.
         final Element mainFileElt = new Element(MAIN_FILE);
         mainFileElt.setText((mainFile == null ? "" : mainFile.getPath()));
         parent.addContent(mainFileElt);
-
+        
         // Write auxiliary directories.
         final Element auxDirElt = new Element(AUX_DIR);
         auxDirElt.setText(Boolean.toString(auxDir));
         parent.addContent(auxDirElt);
-
+        
+        // Write output directories.
+        final Element outDirElt = new Element(OUT_DIR);
+        outDirElt.setText(Boolean.toString(outDir));
+        parent.addContent(outDirElt);
+        
         // Write output format.
         final Element outputFormatElt = new Element(OUTPUT_FORMAT);
         outputFormatElt.setText(outputFormat.name());
         parent.addContent(outputFormatElt);
-
+        
         // Write bibliography run configuration
         final Element bibRunConfigElt = new Element(BIB_RUN_CONFIG);
         bibRunConfigElt.setText(bibRunConfigId);
         parent.addContent(bibRunConfigElt);
     }
-
+    
     void generateBibRunConfig() {
-        RunManagerImpl runManager = RunManagerImpl.getInstanceImpl(getProject());
-
-        RunnerAndConfigurationSettings bibSettings = runManager.createRunConfiguration(
-                "",
-                new LatexConfigurationFactory(new BibtexRunConfigurationType())
-        );
-
-        BibtexRunConfiguration bibtexRunConfiguration = (BibtexRunConfiguration)bibSettings.getConfiguration();
-
+        RunManagerImpl runManager = RunManagerImpl
+                .getInstanceImpl(getProject());
+        
+        RunnerAndConfigurationSettings bibSettings = runManager
+                .createRunConfiguration("", new LatexConfigurationFactory(
+                        new BibtexRunConfigurationType()));
+        
+        BibtexRunConfiguration bibtexRunConfiguration
+                = (BibtexRunConfiguration)bibSettings.getConfiguration();
+        
         bibtexRunConfiguration.setDefaultCompiler();
         bibtexRunConfiguration.setMainFile(mainFile);
         bibtexRunConfiguration.setSuggestedName();
-
+        
         runManager.addConfiguration(bibSettings);
-
+        
         setBibRunConfig(bibSettings);
     }
-
+    
     public LatexCompiler getCompiler() {
         return compiler;
     }
-
+    
     public void setCompiler(LatexCompiler compiler) {
         this.compiler = compiler;
     }
-
+    
     public VirtualFile getMainFile() {
         return this.mainFile;
     }
-
+    
     /**
      * Looks up the corresponding {@link VirtualFile} and calls {@link
      * LatexRunConfiguration#getMainFile()}.
@@ -210,113 +233,138 @@ public class LatexRunConfiguration extends RunConfigurationBase implements Locat
         LocalFileSystem fileSystem = LocalFileSystem.getInstance();
         setMainFile(fileSystem.findFileByPath(mainFilePath));
     }
-
+    
     public void setMainFile(VirtualFile mainFile) {
         this.mainFile = mainFile;
     }
-
+    
     public boolean hasAuxiliaryDirectories() {
         return this.auxDir;
     }
-
+    
+    public boolean hasOutputDirectories() {
+        return this.outDir;
+    }
+    
     public void setAuxiliaryDirectories(boolean auxDir) {
         this.auxDir = auxDir;
     }
-
+    
+    public void setOutputDirectories(boolean outDir) {
+        this.outDir = outDir;
+    }
+    
     public Format getOutputFormat() {
         return outputFormat;
     }
-
+    
     public void setOutputFormat(Format format) {
         this.outputFormat = format;
     }
-
+    
     public void setDefaultCompiler() {
         setCompiler(LatexCompiler.PDFLATEX);
     }
-
+    
     public void setDefaultAuxiliaryDirectories() {
         setAuxiliaryDirectories(true);
     }
-
+    
     public void setDefaultOutputFormat() {
         setOutputFormat(Format.PDF);
     }
-
+    
     public void setSuggestedName() {
         setName(suggestedName());
     }
-
+    
     public String getCompilerPath() {
         return compilerPath;
     }
-
+    
     public void setCompilerPath(String compilerPath) {
         this.compilerPath = compilerPath;
     }
-
+    
     public RunnerAndConfigurationSettings getBibRunConfig() {
-        return RunManagerImpl.getInstanceImpl(getProject()).getConfigurationById(bibRunConfigId);
+        return RunManagerImpl.getInstanceImpl(getProject())
+                .getConfigurationById(bibRunConfigId);
     }
-
+    
     public void setBibRunConfig(RunnerAndConfigurationSettings bibRunConfig) {
-        this.bibRunConfigId = bibRunConfig == null ? "" : bibRunConfig.getUniqueID();
+        this.bibRunConfigId = bibRunConfig == null ? "" :
+                              bibRunConfig.getUniqueID();
     }
-
+    
     public String getCompilerArguments() {
         return compilerArguments;
     }
-
+    
     public void setCompilerArguments(String compilerArguments) {
         if (compilerArguments != null) {
             compilerArguments = compilerArguments.trim();
         }
-
-        this.compilerArguments = compilerArguments != null && compilerArguments.isEmpty() ? null : compilerArguments;
+        
+        this.compilerArguments =
+                compilerArguments != null && compilerArguments.isEmpty() ?
+                null : compilerArguments;
     }
-
+    
     @Override
     public boolean isGeneratedName() {
         if (mainFile == null) {
             return false;
         }
-
+        
         String name = mainFile.getNameWithoutExtension();
         return name != null && name.equals(getName());
     }
-
+    
     @Override
     public String getOutputFilePath() {
-        return ProjectRootManager.getInstance(getProject()).getFileIndex().getContentRootForFile(mainFile).getPath() + "/out/" + mainFile.getNameWithoutExtension() + "." + outputFormat.toString().toLowerCase();
+        String folder;
+        
+        if (outDir) {
+            folder = ProjectRootManager.getInstance(getProject()).getFileIndex()
+                    .getContentRootForFile(mainFile).getPath() + "/out/";
+        }
+        else {
+            folder = mainFile.getParent().getPath() + "/";
+        }
+        
+        return folder + mainFile
+                .getNameWithoutExtension() + "." + outputFormat.toString()
+                .toLowerCase();
     }
-
+    
     @Override
-    public void setFileOutputPath(String fileOutputPath) { }
-
+    public void setFileOutputPath(String fileOutputPath) {
+    }
+    
     @Nullable
     @Override
     public String suggestedName() {
         if (mainFile == null) {
             return null;
         }
-
+        
         return mainFile.getNameWithoutExtension();
     }
-
+    
     @Override
     public String toString() {
         return "LatexRunConfiguration{" + "compiler=" + compiler +
                 ", compilerPath=" + compilerPath +
                 ", mainFile=" + mainFile +
-                ", auxDir=" + auxDir +
+                ", bibWorkingDir=" + auxDir +
                 ", outputFormat=" + outputFormat +
                 '}';
     }
-
+    
     public boolean isSkipBibtex() {
         return skipBibtex;
     }
-
+    
     public void setSkipBibtex(boolean skipBibtex) {
         this.skipBibtex = skipBibtex;
     }

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -17,10 +17,13 @@ import com.intellij.ui.RawCommandLineEditor;
 import com.intellij.ui.SeparatorComponent;
 import com.intellij.ui.TitledSeparator;
 import nl.rubensten.texifyidea.run.LatexCompiler.Format;
+import nl.rubensten.texifyidea.util.PlatformType;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.event.ItemEvent;
+
+import static nl.rubensten.texifyidea.util.PlatformUtilKt.getPlatformType;
 
 /**
  * @author Sten Wessel
@@ -173,19 +176,19 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
 
         // Only add options to disable aux and out folder on Windows.
         // (Disabled on other systems by default.)
-        if (System.getProperty("os.name").contains("Windows")) {
+        if (getPlatformType() == PlatformType.WINDOWS) {
             panel.add(new TitledSeparator("Options"));
             
             // Auxiliary files
             auxDir = new JCheckBox("Separate auxiliary files from output (MiKTeX only)");
             // Only enable by default on Windows.
-            auxDir.setSelected(System.getProperty("os.name").contains("Windows"));
+            auxDir.setSelected(getPlatformType() == PlatformType.WINDOWS);
             panel.add(auxDir);
             
             // Output folder
             outDir = new JCheckBox("Separate output files from source");
             // Only enable by default on Windows.
-            outDir.setSelected(System.getProperty("os.name").contains("Windows"));
+            outDir.setSelected(getPlatformType() == PlatformType.WINDOWS);
             panel.add(outDir);
         }
 

--- a/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
+++ b/src/nl/rubensten/texifyidea/run/LatexSettingsEditor.java
@@ -34,6 +34,7 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
     private LabeledComponent<RawCommandLineEditor> compilerArguments;
     private LabeledComponent<ComponentWithBrowseButton> mainFile;
     private JCheckBox auxDir;
+    private JCheckBox outDir;
     private LabeledComponent<ComboBox> outputFormat;
     private BibliographyPanel bibliographyPanel;
 
@@ -64,6 +65,9 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
 
         // Reset seperate auxiliary files.
         auxDir.setSelected(runConfiguration.hasAuxiliaryDirectories());
+        
+        // Reset seperate output files.
+        outDir.setSelected(runConfiguration.hasOutputDirectories());
 
         // Reset output format.
         outputFormat.getComponent().setSelectedItem(runConfiguration.getOutputFormat());
@@ -96,6 +100,9 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
         // Apply auxiliary files.
         boolean auxDirectories = auxDir.isSelected();
         runConfiguration.setAuxiliaryDirectories(auxDirectories);
+        
+        boolean outDirectories = outDir.isSelected();
+        runConfiguration.setOutputDirectories(outDirectories);
 
         // Apply output format.
         Format format = (Format)outputFormat.getComponent().getSelectedItem();
@@ -164,12 +171,23 @@ public class LatexSettingsEditor extends SettingsEditor<LatexRunConfiguration> {
         mainFile = LabeledComponent.create(mainFileField, "Main file to compile");
         panel.add(mainFile);
 
-        panel.add(new TitledSeparator("Options"));
-
-        // Auxiliary files
-        auxDir = new JCheckBox("Separate auxiliary files from output (MiKTeX only)");
-        auxDir.setSelected(true);
-        panel.add(auxDir);
+        // Only add options to disable aux and out folder on Windows.
+        // (Disabled on other systems by default.)
+        if (System.getProperty("os.name").contains("Windows")) {
+            panel.add(new TitledSeparator("Options"));
+            
+            // Auxiliary files
+            auxDir = new JCheckBox("Separate auxiliary files from output (MiKTeX only)");
+            // Only enable by default on Windows.
+            auxDir.setSelected(System.getProperty("os.name").contains("Windows"));
+            panel.add(auxDir);
+            
+            // Output folder
+            outDir = new JCheckBox("Separate output files from source");
+            // Only enable by default on Windows.
+            outDir.setSelected(System.getProperty("os.name").contains("Windows"));
+            panel.add(outDir);
+        }
 
         // Output format.
         ComboBox<Format> cboxFormat = new ComboBox<>(Format.values());

--- a/src/nl/rubensten/texifyidea/run/compiler/BibtexCompiler.kt
+++ b/src/nl/rubensten/texifyidea/run/compiler/BibtexCompiler.kt
@@ -23,10 +23,13 @@ internal object BibtexCompiler : Compiler<BibtexRunConfiguration> {
             }
             else add(executableName)
 
-            add("-include-directory=${runConfig.mainFile?.parent?.path ?: ""}")
-            addAll(moduleRoots.map { "-include-directory=${it.path}" })
-
             runConfig.compilerArguments?.let { addAll(it.split("""\s+""".toRegex())) }
+
+            // Include files from auxiliary directory on Windows
+            if (System.getProperty("os.name").contains("Windows")) {
+                add("-include-directory=${runConfig.mainFile?.parent?.path ?: ""}")
+                addAll(moduleRoots.map { "-include-directory=${it.path}" })
+            }
 
             add(runConfig.mainFile?.nameWithoutExtension ?: return null)
         }

--- a/src/nl/rubensten/texifyidea/run/compiler/BibtexCompiler.kt
+++ b/src/nl/rubensten/texifyidea/run/compiler/BibtexCompiler.kt
@@ -3,6 +3,8 @@ package nl.rubensten.texifyidea.run.compiler
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import nl.rubensten.texifyidea.run.BibtexRunConfiguration
+import nl.rubensten.texifyidea.util.PlatformType
+import nl.rubensten.texifyidea.util.getPlatformType
 
 /**
  * @author Sten Wessel
@@ -26,7 +28,7 @@ internal object BibtexCompiler : Compiler<BibtexRunConfiguration> {
             runConfig.compilerArguments?.let { addAll(it.split("""\s+""".toRegex())) }
 
             // Include files from auxiliary directory on Windows
-            if (System.getProperty("os.name").contains("Windows")) {
+            if (getPlatformType() == PlatformType.WINDOWS) {
                 add("-include-directory=${runConfig.mainFile?.parent?.path ?: ""}")
                 addAll(moduleRoots.map { "-include-directory=${it.path}" })
             }

--- a/src/nl/rubensten/texifyidea/util/PlatformUtil.kt
+++ b/src/nl/rubensten/texifyidea/util/PlatformUtil.kt
@@ -1,0 +1,23 @@
+package nl.rubensten.texifyidea.util
+
+enum class PlatformType {
+    WINDOWS,
+    LINUX,
+    MACOS,
+    OTHER;
+}
+
+/**
+ * Some platforms have a distinctive part in their name, for example "Windows XP", "Windows 7" etc.
+ * Some platforms have multiple different parts.
+ * This is just a setup which works often, it doesn't cover all cases.
+ */
+fun getPlatformType(): PlatformType {
+    val platformString = System.getProperty("os.name").toLowerCase()
+    return when {
+        platformString.contains("mac") || platformString.contains("darwin") -> PlatformType.MACOS
+        platformString.contains("windows") -> PlatformType.WINDOWS
+        platformString.contains("linux") -> PlatformType.LINUX
+        else -> PlatformType.OTHER
+    }
+}


### PR DESCRIPTION
This PR depends on #732.

#### Additions
Added lualatex as compiler option. And tested that it works on a sample file:

```latex
\documentclass{article}
\usepackage{luacode}

\begin{document}
    A random number:
    \directlua{tex.print(math.random())}
    and another one:
    \begin{luacode}
        tex.print(math.pi)
    \end{luacode}
\end{document}
```

This doesn't automatically select lualatex as compiler, see #737.