### PR TITLE
Use bibtex executablename in bibtex run config

### DIFF
--- a/src/nl/rubensten/texifyidea/run/compiler/BibtexCompiler.kt
+++ b/src/nl/rubensten/texifyidea/run/compiler/BibtexCompiler.kt
@@ -19,7 +19,7 @@ internal object BibtexCompiler : Compiler<BibtexRunConfiguration> {
         val moduleRoots = ProjectRootManager.getInstance(project).contentSourceRoots
 
         command.apply {
-            add(runConfig.compilerPath ?: BiberCompiler.executableName)
+            add(runConfig.compilerPath ?: executableName)
 
             runConfig.compilerArguments?.let { addAll(it.split("""\s+""".toRegex())) }
 


### PR DESCRIPTION
Fixes #765, simple bug with big consequences. As I said, I think we need to run some manual tests for common usage before a release, we would have caught this bug.