### PR TITLE
Syntax highlighting for labels and font style

### DIFF
--- a/src/nl/rubensten/texifyidea/highlighting/LatexAnnotator.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexAnnotator.kt
@@ -183,21 +183,49 @@ open class LatexAnnotator : Annotator {
      * Annotates the given required parameters of commands.
      */
     private fun annotateCommands(command: LatexCommands, annotationHolder: AnnotationHolder) {
+        annotateStyle(command, annotationHolder)
+
         // Label references.
         if (command.name in Magic.Command.reference) {
             command.requiredParameters().firstOrNull()?.let {
-                val content = it.firstChildOfType(LatexContent::class) ?: return@let
-                val annotation = annotationHolder.createInfoAnnotation(content, null)
-                annotation.textAttributes = LatexSyntaxHighlighter.LABEL_REFERENCE
+                annotationHolder.annotateRequiredParameter(it, LatexSyntaxHighlighter.LABEL_REFERENCE)
             }
         }
         // Label definitions.
         else if (command.name in Magic.Command.labelDefinition) {
             command.requiredParameters().firstOrNull()?.let {
-                val content = it.firstChildOfType(LatexContent::class) ?: return@let
-                val annotation = annotationHolder.createInfoAnnotation(content, null)
-                annotation.textAttributes = LatexSyntaxHighlighter.LABEL_DEFINITION
+                annotationHolder.annotateRequiredParameter(it, LatexSyntaxHighlighter.LABEL_DEFINITION)
             }
         }
+    }
+
+    /**
+     * Annotates the command according to its font style, i.e. \textbf{} gets annotated with the `STYLE_BOLD` style.
+     */
+    private fun annotateStyle(command: LatexCommands, annotationHolder: AnnotationHolder) {
+        val style = when (command.name) {
+            "\\textbf" -> LatexSyntaxHighlighter.STYLE_BOLD
+            "\\textit" -> LatexSyntaxHighlighter.STYLE_ITALIC
+            "\\underline" -> LatexSyntaxHighlighter.STYLE_UNDERLINE
+            "\\sout" -> LatexSyntaxHighlighter.STYLE_STRIKETHROUGH
+            "\\textsc" -> LatexSyntaxHighlighter.STYLE_SMALL_CAPITALS
+            "\\overline" -> LatexSyntaxHighlighter.STYLE_OVERLINE
+            "\\texttt" -> LatexSyntaxHighlighter.STYLE_TYPEWRITER
+            "\\textsl" -> LatexSyntaxHighlighter.STYLE_SLANTED
+            else -> return
+        }
+
+        command.requiredParameters().firstOrNull()?.let {
+            annotationHolder.annotateRequiredParameter(it, style)
+        }
+    }
+
+    /**
+     * Annotates the contents of the given parameter with the given style.
+     */
+    private fun AnnotationHolder.annotateRequiredParameter(parameter: LatexRequiredParam, style: TextAttributesKey) {
+        val content = parameter.firstChildOfType(LatexContent::class) ?: return
+        val annotation = createInfoAnnotation(content, null)
+        annotation.textAttributes = style
     }
 }

--- a/src/nl/rubensten/texifyidea/highlighting/LatexAnnotator.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexAnnotator.kt
@@ -88,6 +88,10 @@ open class LatexAnnotator : Annotator {
         else if (psiElement is LatexOptionalParam) {
             annotateOptionalParameters(psiElement, annotationHolder)
         }
+        // Commands
+        else if (psiElement is LatexCommands) {
+            annotateCommands(psiElement, annotationHolder)
+        }
     }
 
     /**
@@ -172,6 +176,28 @@ open class LatexAnnotator : Annotator {
             val toStyle = noMathContent.normalText ?: continue
             val annotation = annotationHolder.createInfoAnnotation(toStyle, null)
             annotation.textAttributes = LatexSyntaxHighlighter.OPTIONAL_PARAM
+        }
+    }
+
+    /**
+     * Annotates the given required parameters of commands.
+     */
+    private fun annotateCommands(command: LatexCommands, annotationHolder: AnnotationHolder) {
+        // Label references.
+        if (command.name in Magic.Command.reference) {
+            command.requiredParameters().firstOrNull()?.let {
+                val content = it.firstChildOfType(LatexContent::class) ?: return@let
+                val annotation = annotationHolder.createInfoAnnotation(content, null)
+                annotation.textAttributes = LatexSyntaxHighlighter.LABEL_REFERENCE
+            }
+        }
+        // Label definitions.
+        else if (command.name in Magic.Command.labelDefinition) {
+            command.requiredParameters().firstOrNull()?.let {
+                val content = it.firstChildOfType(LatexContent::class) ?: return@let
+                val annotation = annotationHolder.createInfoAnnotation(content, null)
+                annotation.textAttributes = LatexSyntaxHighlighter.LABEL_DEFINITION
+            }
         }
     }
 }

--- a/src/nl/rubensten/texifyidea/highlighting/LatexAnnotator.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexAnnotator.kt
@@ -186,16 +186,25 @@ open class LatexAnnotator : Annotator {
         annotateStyle(command, annotationHolder)
 
         // Label references.
-        if (command.name in Magic.Command.reference) {
-            command.requiredParameters().firstOrNull()?.let {
-                annotationHolder.annotateRequiredParameter(it, LatexSyntaxHighlighter.LABEL_REFERENCE)
-            }
+        val style = if (command.name in Magic.Command.labelReference) {
+            LatexSyntaxHighlighter.LABEL_REFERENCE
         }
         // Label definitions.
         else if (command.name in Magic.Command.labelDefinition) {
-            command.requiredParameters().firstOrNull()?.let {
-                annotationHolder.annotateRequiredParameter(it, LatexSyntaxHighlighter.LABEL_DEFINITION)
-            }
+            LatexSyntaxHighlighter.LABEL_DEFINITION
+        }
+        // Bibliography references (citations).
+        else if (command.name in Magic.Command.bibliographyReference) {
+            LatexSyntaxHighlighter.BIBLIOGRAPHY_REFERENCE
+        }
+        // Label definitions.
+        else if (command.name in Magic.Command.bibliographyItems) {
+            LatexSyntaxHighlighter.BIBLIOGRAPHY_DEFINITION
+        }
+        else return
+
+        command.requiredParameters().firstOrNull()?.let {
+            annotationHolder.annotateRequiredParameter(it, style!!)
         }
     }
 

--- a/src/nl/rubensten/texifyidea/highlighting/LatexColorSettingsPage.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexColorSettingsPage.kt
@@ -25,8 +25,10 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 AttributesDescriptor("Commands//Commands in display math mode", LatexSyntaxHighlighter.COMMAND_MATH_DISPLAY),
                 AttributesDescriptor("Commands//Stars", LatexSyntaxHighlighter.STAR),
                 AttributesDescriptor("Comments", LatexSyntaxHighlighter.COMMENT),
-                AttributesDescriptor("Labels//Label definition", LatexSyntaxHighlighter.LABEL_DEFINITION),
-                AttributesDescriptor("Labels//Label references", LatexSyntaxHighlighter.LABEL_REFERENCE),
+                AttributesDescriptor("References//Label definition", LatexSyntaxHighlighter.LABEL_DEFINITION),
+                AttributesDescriptor("References//Label reference", LatexSyntaxHighlighter.LABEL_REFERENCE),
+                AttributesDescriptor("References//Bibliography item", LatexSyntaxHighlighter.BIBLIOGRAPHY_DEFINITION),
+                AttributesDescriptor("References//Citation", LatexSyntaxHighlighter.BIBLIOGRAPHY_REFERENCE),
                 AttributesDescriptor("Math//Inline math", LatexSyntaxHighlighter.INLINE_MATH),
                 AttributesDescriptor("Math//Display math", LatexSyntaxHighlighter.DISPLAY_MATH),
 
@@ -51,6 +53,8 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 "comment" to LatexSyntaxHighlighter.COMMENT,
                 "labelDefinition" to LatexSyntaxHighlighter.LABEL_DEFINITION,
                 "reference" to LatexSyntaxHighlighter.LABEL_REFERENCE,
+                "bibliographyDefinition" to LatexSyntaxHighlighter.BIBLIOGRAPHY_DEFINITION,
+                "bibliographyReference" to LatexSyntaxHighlighter.BIBLIOGRAPHY_REFERENCE,
                 "styleBold" to LatexSyntaxHighlighter.STYLE_BOLD,
                 "styleItalic" to LatexSyntaxHighlighter.STYLE_ITALIC,
                 "styleUnderline" to LatexSyntaxHighlighter.STYLE_UNDERLINE,
@@ -111,7 +115,7 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |    \]</displayMath>
                 |
                 |    \section{More work}\label{<labelDefinition>sec:moreWork</labelDefinition>}
-                |    A much longer \LaTeXe{} example was written by Henk-Jan~\cite{<reference>Gil:02</reference>}. But
+                |    A much longer \LaTeXe{} example was written by Henk-Jan~\cite{<bibliographyReference>Gil:02</bibliographyReference>}. But
                 |    we can also just do some more epic plugin showoffy stuff like
                 |    <displayMath>\begin{align}
                 |       <displayCommand>\text</displayCommand>{Stuff here is also highlighted, and also }
@@ -138,6 +142,13 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |    % Another extremely descriptive comment.
                 |    \bibliographystyle{abbrv}
                 |    \bibliography{main}
+                |
+                |    \begin{thebibliography}{9}
+                |        \bibitem{<bibliographyDefinition>latexcompanion</bibliographyDefinition>}
+                |        Michel Goossens, Frank Mittelbach, and Alexander Samarin.
+                |        \textit{<styleItalic>The \LaTeX\ Companion</styleItalic>}.
+                |        Addison-Wesley, Reading, Massachusetts, 1993.
+                |    \end{thebibliography}
                 |
                 |\end{document}
         """.trimMargin()

--- a/src/nl/rubensten/texifyidea/highlighting/LatexColorSettingsPage.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexColorSettingsPage.kt
@@ -12,21 +12,36 @@ class LatexColorSettingsPage : ColorSettingsPage {
 
     companion object {
 
+        /*
+         * You can group multiple descriptors by prefixing it with the group name and '//'. FYI.
+         */
+        @JvmStatic
         val DESCRIPTORS = arrayOf(
                 AttributesDescriptor("Braces", LatexSyntaxHighlighter.BRACES),
                 AttributesDescriptor("Brackets", LatexSyntaxHighlighter.BRACKETS),
-                AttributesDescriptor("Optional parameters", LatexSyntaxHighlighter.OPTIONAL_PARAM),
-                AttributesDescriptor("Commands", LatexSyntaxHighlighter.COMMAND),
-                AttributesDescriptor("Commands in inline math mode", LatexSyntaxHighlighter.COMMAND_MATH_INLINE),
-                AttributesDescriptor("Commands in display math mode", LatexSyntaxHighlighter.COMMAND_MATH_DISPLAY),
+                AttributesDescriptor("Commands//Optional parameters", LatexSyntaxHighlighter.OPTIONAL_PARAM),
+                AttributesDescriptor("Commands//Commands", LatexSyntaxHighlighter.COMMAND),
+                AttributesDescriptor("Commands//Commands in inline math mode", LatexSyntaxHighlighter.COMMAND_MATH_INLINE),
+                AttributesDescriptor("Commands//Commands in display math mode", LatexSyntaxHighlighter.COMMAND_MATH_DISPLAY),
+                AttributesDescriptor("Commands//Stars", LatexSyntaxHighlighter.STAR),
                 AttributesDescriptor("Comments", LatexSyntaxHighlighter.COMMENT),
-                AttributesDescriptor("Label definition", LatexSyntaxHighlighter.LABEL_DEFINITION),
-                AttributesDescriptor("Label references", LatexSyntaxHighlighter.LABEL_REFERENCE),
-                AttributesDescriptor("Inline math", LatexSyntaxHighlighter.INLINE_MATH),
-                AttributesDescriptor("Display math", LatexSyntaxHighlighter.DISPLAY_MATH),
-                AttributesDescriptor("Stars", LatexSyntaxHighlighter.STAR)
+                AttributesDescriptor("Labels//Label definition", LatexSyntaxHighlighter.LABEL_DEFINITION),
+                AttributesDescriptor("Labels//Label references", LatexSyntaxHighlighter.LABEL_REFERENCE),
+                AttributesDescriptor("Math//Inline math", LatexSyntaxHighlighter.INLINE_MATH),
+                AttributesDescriptor("Math//Display math", LatexSyntaxHighlighter.DISPLAY_MATH),
+
+                // Styles
+                AttributesDescriptor("Font style//Bold", LatexSyntaxHighlighter.STYLE_BOLD),
+                AttributesDescriptor("Font style//Italics", LatexSyntaxHighlighter.STYLE_ITALIC),
+                AttributesDescriptor("Font style//Underline", LatexSyntaxHighlighter.STYLE_UNDERLINE),
+                AttributesDescriptor("Font style//Strikethrough", LatexSyntaxHighlighter.STYLE_STRIKETHROUGH),
+                AttributesDescriptor("Font style//Small capitals", LatexSyntaxHighlighter.STYLE_SMALL_CAPITALS),
+                AttributesDescriptor("Font style//Overline", LatexSyntaxHighlighter.STYLE_OVERLINE),
+                AttributesDescriptor("Font style//Typewriter", LatexSyntaxHighlighter.STYLE_TYPEWRITER),
+                AttributesDescriptor("Font style//Slanted", LatexSyntaxHighlighter.STYLE_SLANTED)
         )
 
+        @JvmStatic
         val DEMO_TAGS = mapOf(
             "displayCommand" to LatexSyntaxHighlighter.COMMAND_MATH_DISPLAY,
                 "inlineCommand" to LatexSyntaxHighlighter.COMMAND_MATH_INLINE,
@@ -35,7 +50,15 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 "optionalParam" to LatexSyntaxHighlighter.OPTIONAL_PARAM,
                 "comment" to LatexSyntaxHighlighter.COMMENT,
                 "labelDefinition" to LatexSyntaxHighlighter.LABEL_DEFINITION,
-                "reference" to LatexSyntaxHighlighter.LABEL_REFERENCE
+                "reference" to LatexSyntaxHighlighter.LABEL_REFERENCE,
+                "styleBold" to LatexSyntaxHighlighter.STYLE_BOLD,
+                "styleItalic" to LatexSyntaxHighlighter.STYLE_ITALIC,
+                "styleUnderline" to LatexSyntaxHighlighter.STYLE_UNDERLINE,
+                "styleStrikethrough" to LatexSyntaxHighlighter.STYLE_STRIKETHROUGH,
+                "styleSmallCapitals" to LatexSyntaxHighlighter.STYLE_SMALL_CAPITALS,
+                "styleOverline" to LatexSyntaxHighlighter.STYLE_OVERLINE,
+                "styleTypewriter" to LatexSyntaxHighlighter.STYLE_TYPEWRITER,
+                "styleSlanted" to LatexSyntaxHighlighter.STYLE_SLANTED
         )
     }
 
@@ -60,7 +83,7 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |    \title{A Very Simple \LaTeXe{} Template}
                 |    \author{
                 |            Henk-Jan\\Department of YUROP\\University of Cheese\\
-                |            Windmill City, 2198 AL, \underline{Tulipa}
+                |            Windmill City, 2198 AL, \underline{<styleUnderline>Tulipa</styleUnderline>}
                 |    }
                 |    \date{\today}
                 |    \maketitle
@@ -76,10 +99,10 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |
                 |    \section{Introduction}\label{<labelDefinition>sec:introduction</labelDefinition>}
                 |    This is time for all good men to come to the aid of
-                |    their party!~\cite{<reference>some-bibitem</reference>}
+                |    their party!
                 |    For the end see~\ref{<reference>sec:conclusions</reference>}.
                 |
-                |    \paragraph{Mathematics}
+                |    \paragraph*{Mathematics}
                 |    Please take a look at the value of <inlineMath>${'$'}x <inlineCommand>\times</inlineCommand>
                 |    <inlineCommand>\frac</inlineCommand>{5}{<inlineCommand>\sqrt</inlineCommand>{3}}${'$'}</inlineMath> in the following equation:
                 |    <displayMath>\[
@@ -88,7 +111,7 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |    \]</displayMath>
                 |
                 |    \section{More work}\label{<labelDefinition>sec:moreWork</labelDefinition>}
-                |    A much longer \LaTeXe{} example was written by Henk-Jan~\cite{Gil:02}. But
+                |    A much longer \LaTeXe{} example was written by Henk-Jan~\cite{<reference>Gil:02</reference>}. But
                 |    we can also just do some more epic plugin showoffy stuff like
                 |    <displayMath>\begin{align}
                 |       <displayCommand>\text</displayCommand>{Stuff here is also highlighted, and also }
@@ -98,6 +121,16 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |    \section{Results}\label{<labelDefinition>sec:results</labelDefinition>}
                 |    In this section we describe the results. So basically <inlineMath>${'$'}x${'$'}</inlineMath> but maybe
                 |    also <inlineMath>${'$'}<inlineCommand>\hat</inlineCommand>{x}^{2y}${'$'}</inlineMath>.
+                |
+                |    Also, some text styles:
+                |    \textbf{<styleBold>Bold</styleBold>}
+                |    \textit{<styleItalic>Italic</styleItalic>}
+                |    \underline{<styleUnderline>Underline</styleUnderline>}
+                |    \sout{<styleStrikethrough>Strikethrough</styleStrikethrough>}
+                |    \textsc{<styleSmallCapitals>SMALL CAPITALS</styleSmallCapitals>}
+                |    \overline{<styleOverline>Overline</styleOverline>}
+                |    \texttt{<styleTypewriter>Typewriter</styleTypewriter>}
+                |    \textsl{<styleSlanted>Slanted</styleSlanted>}
                 |
                 |    \section{Conclusions}\label{<labelDefinition>sec:conclusions</labelDefinition>}
                 |    We worked hard, and achieved very little. Or did we?

--- a/src/nl/rubensten/texifyidea/highlighting/LatexColorSettingsPage.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexColorSettingsPage.kt
@@ -20,6 +20,8 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 AttributesDescriptor("Commands in inline math mode", LatexSyntaxHighlighter.COMMAND_MATH_INLINE),
                 AttributesDescriptor("Commands in display math mode", LatexSyntaxHighlighter.COMMAND_MATH_DISPLAY),
                 AttributesDescriptor("Comments", LatexSyntaxHighlighter.COMMENT),
+                AttributesDescriptor("Label definition", LatexSyntaxHighlighter.LABEL_DEFINITION),
+                AttributesDescriptor("Label references", LatexSyntaxHighlighter.LABEL_REFERENCE),
                 AttributesDescriptor("Inline math", LatexSyntaxHighlighter.INLINE_MATH),
                 AttributesDescriptor("Display math", LatexSyntaxHighlighter.DISPLAY_MATH),
                 AttributesDescriptor("Stars", LatexSyntaxHighlighter.STAR)
@@ -31,7 +33,9 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 "displayMath" to LatexSyntaxHighlighter.DISPLAY_MATH,
                 "inlineMath" to LatexSyntaxHighlighter.INLINE_MATH,
                 "optionalParam" to LatexSyntaxHighlighter.OPTIONAL_PARAM,
-                "comment" to LatexSyntaxHighlighter.COMMENT
+                "comment" to LatexSyntaxHighlighter.COMMENT,
+                "labelDefinition" to LatexSyntaxHighlighter.LABEL_DEFINITION,
+                "reference" to LatexSyntaxHighlighter.LABEL_REFERENCE
         )
     }
 
@@ -70,8 +74,10 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |        Yes, even comment environments get highlighted.
                 |    \end{comment}</comment>
                 |
-                |    \section{Introduction}\label{sec:introduction}
-                |    This is time for all good men to come to the aid of their party!
+                |    \section{Introduction}\label{<labelDefinition>sec:introduction</labelDefinition>}
+                |    This is time for all good men to come to the aid of
+                |    their party!~\cite{<reference>some-bibitem</reference>}
+                |    For the end see~\ref{<reference>sec:conclusions</reference>}.
                 |
                 |    \paragraph{Mathematics}
                 |    Please take a look at the value of <inlineMath>${'$'}x <inlineCommand>\times</inlineCommand>
@@ -81,7 +87,7 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |           <displayCommand>\sqrt</displayCommand>[<optionalParam>1234</optionalParam>]{5678}.
                 |    \]</displayMath>
                 |
-                |    \section{More work}\label{sec:moreWork}
+                |    \section{More work}\label{<labelDefinition>sec:moreWork</labelDefinition>}
                 |    A much longer \LaTeXe{} example was written by Henk-Jan~\cite{Gil:02}. But
                 |    we can also just do some more epic plugin showoffy stuff like
                 |    <displayMath>\begin{align}
@@ -89,11 +95,11 @@ class LatexColorSettingsPage : ColorSettingsPage {
                 |       <displayCommand>\sum</displayCommand>_{i=0}^n <displayCommand>\left</displayCommand>( i <displayCommand>\right</displayCommand>)
                 |    \begin{align}</displayMath>
                 |
-                |    \section{Results}\label{sec:results}
+                |    \section{Results}\label{<labelDefinition>sec:results</labelDefinition>}
                 |    In this section we describe the results. So basically <inlineMath>${'$'}x${'$'}</inlineMath> but maybe
                 |    also <inlineMath>${'$'}<inlineCommand>\hat</inlineCommand>{x}^{2y}${'$'}</inlineMath>.
                 |
-                |    \section{Conclusions}\label{sec:conclusions}
+                |    \section{Conclusions}\label{<labelDefinition>sec:conclusions</labelDefinition>}
                 |    We worked hard, and achieved very little. Or did we?
                 |
                 |    % Another extremely descriptive comment.

--- a/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
@@ -69,6 +69,16 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
             DefaultLanguageHighlighterColors.DOT
     );
 
+    public static final TextAttributesKey LABEL_DEFINITION = TextAttributesKey.createTextAttributesKey(
+            "LATEX_LABEL_DEFINITION",
+            DefaultLanguageHighlighterColors.IDENTIFIER
+    );
+
+    public static final TextAttributesKey LABEL_REFERENCE = TextAttributesKey.createTextAttributesKey(
+            "LATEX_LABEL_REFERENCE",
+            DefaultLanguageHighlighterColors.IDENTIFIER
+    );
+
     /*
      * TokenSets
      */
@@ -107,6 +117,14 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
 
     private static final TextAttributesKey[] STAR_KEYS = new TextAttributesKey[] {
             STAR
+    };
+
+    private static final TextAttributesKey[] LABEL_DEFINITION_KEYS = new TextAttributesKey[] {
+            LABEL_DEFINITION
+    };
+
+    private static final TextAttributesKey[] LABEL_REFERENCE_KEYS = new TextAttributesKey[] {
+            LABEL_REFERENCE
     };
 
     private static final TextAttributesKey[] EMPTY_KEYS = new TextAttributesKey[0];

--- a/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
@@ -30,6 +30,8 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
     public static final TextAttributesKey STAR = createKey("LATEX_STAR", DefaultLanguageHighlighterColors.DOT);
     public static final TextAttributesKey LABEL_DEFINITION = createKey("LATEX_LABEL_DEFINITION", DefaultLanguageHighlighterColors.IDENTIFIER);
     public static final TextAttributesKey LABEL_REFERENCE = createKey("LATEX_LABEL_REFERENCE", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey BIBLIOGRAPHY_DEFINITION = createKey("LATEX_BIBLIOGRAPHY_DEFINITION", LABEL_DEFINITION);
+    public static final TextAttributesKey BIBLIOGRAPHY_REFERENCE = createKey("LATEX_BIBLIOGRAPHY_REFERENCE", LABEL_REFERENCE);
     public static final TextAttributesKey STYLE_BOLD = createKey("LATEX_STYLE_BOLD", DefaultLanguageHighlighterColors.IDENTIFIER);
     public static final TextAttributesKey STYLE_ITALIC = createKey("LATEX_STYLE_ITALIC", DefaultLanguageHighlighterColors.IDENTIFIER);
     public static final TextAttributesKey STYLE_UNDERLINE = createKey("LATEX_STYLE_UNDERLINE", DefaultLanguageHighlighterColors.IDENTIFIER);

--- a/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexSyntaxHighlighter.java
@@ -18,70 +18,27 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
     /*
      * TextAttributesKeys
      */
-    public static final TextAttributesKey BRACES = TextAttributesKey.createTextAttributesKey(
-            "LATEX_BRACES",
-            DefaultLanguageHighlighterColors.BRACES
-    );
+    public static final TextAttributesKey BRACES = createKey("LATEX_BRACES", DefaultLanguageHighlighterColors.BRACES);
+    public static final TextAttributesKey BRACKETS = createKey("LATEX_BRACKETS", DefaultLanguageHighlighterColors.BRACKETS);
+    public static final TextAttributesKey OPTIONAL_PARAM = createKey("LATEX_OPTIONAL_PARAM", DefaultLanguageHighlighterColors.PARAMETER);
+    public static final TextAttributesKey COMMAND = createKey("LATEX_COMMAND", DefaultLanguageHighlighterColors.KEYWORD);
+    public static final TextAttributesKey COMMAND_MATH_INLINE = createKey("LATEX_COMMAND_MATH_INLINE", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE);
+    public static final TextAttributesKey COMMAND_MATH_DISPLAY = createKey("LATEX_COMMAND_MATH_DISPLAY", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE);
+    public static final TextAttributesKey COMMENT = createKey("LATEX_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
+    public static final TextAttributesKey INLINE_MATH = createKey("LATEX_INLINE_MATH", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey DISPLAY_MATH = createKey("LATEX_DISPLAY_MATH", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey STAR = createKey("LATEX_STAR", DefaultLanguageHighlighterColors.DOT);
+    public static final TextAttributesKey LABEL_DEFINITION = createKey("LATEX_LABEL_DEFINITION", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey LABEL_REFERENCE = createKey("LATEX_LABEL_REFERENCE", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_BOLD = createKey("LATEX_STYLE_BOLD", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_ITALIC = createKey("LATEX_STYLE_ITALIC", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_UNDERLINE = createKey("LATEX_STYLE_UNDERLINE", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_STRIKETHROUGH = createKey("LATEX_STYLE_STRIKETHROUGH", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_SMALL_CAPITALS = createKey("LATEX_STYLE_SMALL_CAPITALS", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_OVERLINE = createKey("LATEX_STYLE_OVERLINE", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_TYPEWRITER = createKey("LATEX_STYLE_TYPEWRITER", DefaultLanguageHighlighterColors.IDENTIFIER);
+    public static final TextAttributesKey STYLE_SLANTED = createKey("LATEX_STYLE_SLANTED", DefaultLanguageHighlighterColors.IDENTIFIER);
 
-    public static final TextAttributesKey BRACKETS = TextAttributesKey.createTextAttributesKey(
-            "LATEX_BRACKETS",
-            DefaultLanguageHighlighterColors.BRACKETS
-    );
-
-    public static final TextAttributesKey OPTIONAL_PARAM = TextAttributesKey.createTextAttributesKey(
-            "LATEX_OPTIONAL_PARAM",
-            DefaultLanguageHighlighterColors.PARAMETER
-    );
-
-    public static final TextAttributesKey COMMAND = TextAttributesKey.createTextAttributesKey(
-            "LATEX_COMMAND",
-            DefaultLanguageHighlighterColors.KEYWORD
-    );
-
-    public static final TextAttributesKey COMMAND_MATH_INLINE = TextAttributesKey.createTextAttributesKey(
-            "LATEX_COMMAND_MATH_INLINE",
-            DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE
-    );
-
-    public static final TextAttributesKey COMMAND_MATH_DISPLAY = TextAttributesKey
-            .createTextAttributesKey(
-            "LATEX_COMMAND_MATH_DISPLAY",
-            DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE
-    );
-
-    public static final TextAttributesKey COMMENT = TextAttributesKey.createTextAttributesKey(
-            "LATEX_COMMENT",
-            DefaultLanguageHighlighterColors.LINE_COMMENT
-    );
-
-    public static final TextAttributesKey INLINE_MATH = TextAttributesKey.createTextAttributesKey(
-            "LATEX_INLINE_MATH",
-            DefaultLanguageHighlighterColors.STRING
-    );
-
-    public static final TextAttributesKey DISPLAY_MATH = TextAttributesKey.createTextAttributesKey(
-            "LATEX_DISPLAY_MATH",
-            DefaultLanguageHighlighterColors.STRING
-    );
-
-    public static final TextAttributesKey STAR = TextAttributesKey.createTextAttributesKey(
-            "LATEX_STAR",
-            DefaultLanguageHighlighterColors.DOT
-    );
-
-    public static final TextAttributesKey LABEL_DEFINITION = TextAttributesKey.createTextAttributesKey(
-            "LATEX_LABEL_DEFINITION",
-            DefaultLanguageHighlighterColors.IDENTIFIER
-    );
-
-    public static final TextAttributesKey LABEL_REFERENCE = TextAttributesKey.createTextAttributesKey(
-            "LATEX_LABEL_REFERENCE",
-            DefaultLanguageHighlighterColors.IDENTIFIER
-    );
-
-    /*
-     * TokenSets
-     */
     private static final TokenSet COMMAND_TOKENS = TokenSet.create(
             LatexTypes.COMMAND_TOKEN,
             LatexTypes.BEGIN_TOKEN,
@@ -91,43 +48,22 @@ public class LatexSyntaxHighlighter extends SyntaxHighlighterBase {
     /*
      * TextAttributeKey[]s
      */
-    private static final TextAttributesKey[] BRACES_KEYS = new TextAttributesKey[] {
-            BRACES
-    };
-
-    private static final TextAttributesKey[] BRACKET_KEYS = new TextAttributesKey[] {
-            BRACKETS
-    };
-
-    private static final TextAttributesKey[] COMMAND_KEYS = new TextAttributesKey[] {
-            COMMAND
-    };
-
-    private static final TextAttributesKey[] COMMENT_KEYS = new TextAttributesKey[] {
-            COMMENT
-    };
-
-    private static final TextAttributesKey[] INLINE_MATH_KEYS = new TextAttributesKey[] {
-            INLINE_MATH
-    };
-
-    private static final TextAttributesKey[] DISPLAY_MATH_KEYS = new TextAttributesKey[] {
-            DISPLAY_MATH
-    };
-
-    private static final TextAttributesKey[] STAR_KEYS = new TextAttributesKey[] {
-            STAR
-    };
-
-    private static final TextAttributesKey[] LABEL_DEFINITION_KEYS = new TextAttributesKey[] {
-            LABEL_DEFINITION
-    };
-
-    private static final TextAttributesKey[] LABEL_REFERENCE_KEYS = new TextAttributesKey[] {
-            LABEL_REFERENCE
-    };
-
+    private static final TextAttributesKey[] BRACES_KEYS = keys(BRACES);
+    private static final TextAttributesKey[] BRACKET_KEYS = keys(BRACKETS);
+    private static final TextAttributesKey[] COMMAND_KEYS = keys(COMMAND);
+    private static final TextAttributesKey[] COMMENT_KEYS = keys(COMMENT);
+    private static final TextAttributesKey[] INLINE_MATH_KEYS = keys(INLINE_MATH);
+    private static final TextAttributesKey[] DISPLAY_MATH_KEYS = keys(DISPLAY_MATH);
+    private static final TextAttributesKey[] STAR_KEYS = keys(STAR);
     private static final TextAttributesKey[] EMPTY_KEYS = new TextAttributesKey[0];
+
+    private static TextAttributesKey createKey(String externalName, TextAttributesKey defaultStyle) {
+        return TextAttributesKey.createTextAttributesKey(externalName, defaultStyle);
+    }
+
+    private static TextAttributesKey[] keys(TextAttributesKey... keys) {
+        return keys;
+    }
 
     @NotNull
     @Override

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -118,6 +118,11 @@ object Magic {
         @JvmField val reference = labelReference + bibliographyReference
 
         /**
+         * All commands that define labels.
+         */
+        @JvmField val labelDefinition = setOf("\\label", "\\bibitem")
+
+        /**
          * All math operators without a leading slash.
          */
         @JvmField val slashlessMathOperators = hashSetOf(

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -120,7 +120,12 @@ object Magic {
         /**
          * All commands that define labels.
          */
-        @JvmField val labelDefinition = setOf("\\label", "\\bibitem")
+        @JvmField val labelDefinition = setOf("\\label")
+
+        /**
+         * All commands that define bibliography items.
+         */
+        @JvmField val bibliographyItems = setOf("\\bibitem")
 
         /**
          * All math operators without a leading slash.


### PR DESCRIPTION
Resolves #772 and Resolves #774.

#### Additions
- Added syntax highlighting for references and reference definitions.
- Added syntax highlighting for style commands like `\textbf`.
- Both settings are disabled by default (making use of default style). Highlighting can be turned on by the users themselves.

#### Changes
- Grouped attribute descriptors in colour highlighting settings page.
- Updated the example text accordingly.

#### Screenshots
![image](https://user-images.githubusercontent.com/17410729/49291308-2e1bed80-f4aa-11e8-8d51-59b5ce098eb0.png)

![image](https://user-images.githubusercontent.com/17410729/49291376-63c0d680-f4aa-11e8-961a-60bbda3fa48e.png)
