### PR TITLE
Commands update

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -331,10 +331,15 @@
         <codeInsight.parameterInfo language="Latex" implementationClass="nl.rubensten.texifyidea.insight.LatexParameterInfoHandler"/>
         <typedHandler implementation="nl.rubensten.texifyidea.highlighting.LatexTypedHandler"/>
         <lookup.charFilter implementation="nl.rubensten.texifyidea.completion.LatexCharFilter" id="latex"/>
-        <enterHandlerDelegate implementation="nl.rubensten.texifyidea.editor.InsertEnumerationItem" />
-        <typedHandler implementation="nl.rubensten.texifyidea.editor.ShiftTracker" />
-        <typedHandler implementation="nl.rubensten.texifyidea.editor.UpDownAutoBracket" />
+        <enterHandlerDelegate implementation="nl.rubensten.texifyidea.editor.InsertEnumerationItem"/>
+        <typedHandler implementation="nl.rubensten.texifyidea.editor.ShiftTracker"/>
+        <typedHandler implementation="nl.rubensten.texifyidea.editor.UpDownAutoBracket"/>
         <typedHandler implementation="nl.rubensten.texifyidea.editor.BibtexQuoteInsertHandler"/>
+
+        <!-- Navigation -->
+        <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoLabelSymbolContributor"/>
+        <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoCommandDefinitionSymbolContributor"/>
+        <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoEnvironmentDefinitionSymbolContributor"/>
 
         <!-- Line markers -->
         <codeInsight.lineMarkerProvider language="Latex" implementationClass="nl.rubensten.texifyidea.gutter.LatexNavigationGutter"/>

--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -105,7 +105,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         Collections.addAll(environments, DefaultEnvironment.values());
 
         LatexDefinitionIndex.Companion.getItemsInFileSet(parameters.getOriginalFile()).stream()
-                .filter(cmd -> "\\newenvironment".equals(cmd.getName()))
+                .filter(cmd -> Magic.Command.environmentDefinitions.contains(cmd.getName()))
                 .map(cmd -> PsiCommandsKt.requiredParameter(cmd, 0))
                 .filter(Objects::nonNull)
                 .map(SimpleEnvironment::new)

--- a/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
+++ b/src/nl/rubensten/texifyidea/completion/LatexCommandProvider.java
@@ -62,7 +62,7 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
 
     private void addNormalCommands(CompletionResultSet result) {
         result.addAllElements(ContainerUtil.map2List(
-                LatexNoMathCommand.values(),
+                LatexRegularCommand.values(),
                 cmd -> LookupElementBuilder.create(cmd, cmd.getCommand())
                         .withPresentableText(cmd.getCommandDisplay())
                         .bold()
@@ -78,13 +78,13 @@ public class LatexCommandProvider extends CompletionProvider<CompletionParameter
         // Find all commands.
         List<LatexCommand> commands = new ArrayList<>();
         Collections.addAll(commands, LatexMathCommand.values());
-        commands.add(LatexNoMathCommand.BEGIN);
+        commands.add(LatexRegularCommand.BEGIN);
 
         // Create autocomplete elements.
         result.addAllElements(ContainerUtil.map2List(
                 commands,
                 cmd -> {
-                    InsertHandler<LookupElement> handler = cmd instanceof LatexNoMathCommand ?
+                    InsertHandler<LookupElement> handler = cmd instanceof LatexRegularCommand ?
                             new LatexNoMathInsertHandler() :
                             new LatexMathInsertHandler();
 

--- a/src/nl/rubensten/texifyidea/completion/TexifyCompletionContributor.kt
+++ b/src/nl/rubensten/texifyidea/completion/TexifyCompletionContributor.kt
@@ -11,7 +11,7 @@ import com.intellij.util.ProcessingContext
 import nl.rubensten.texifyidea.BibtexLanguage
 import nl.rubensten.texifyidea.LatexLanguage
 import nl.rubensten.texifyidea.lang.LatexMode
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand
+import nl.rubensten.texifyidea.lang.LatexRegularCommand
 import nl.rubensten.texifyidea.lang.RequiredFileArgument
 import nl.rubensten.texifyidea.psi.*
 import nl.rubensten.texifyidea.util.firstChildOfType
@@ -87,7 +87,7 @@ open class TexifyCompletionContributor : CompletionContributor() {
                                 val command = LatexPsiUtil.getParentOfType(psiElement, LatexCommands::class.java) ?: return false
 
                                 val name = command.commandToken.text
-                                val cmd = LatexNoMathCommand[name.substring(1)] ?: return false
+                                val cmd = LatexRegularCommand[name.substring(1)] ?: return false
 
                                 val args = cmd.getArgumentsOf(RequiredFileArgument::class)
                                 return !args.isEmpty()

--- a/src/nl/rubensten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.java
+++ b/src/nl/rubensten/texifyidea/completion/handlers/LatexCommandArgumentInsertHandler.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import nl.rubensten.texifyidea.lang.LatexMathCommand;
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
+import nl.rubensten.texifyidea.lang.LatexRegularCommand;
 import nl.rubensten.texifyidea.psi.LatexCommands;
 
 import java.util.List;
@@ -28,8 +28,8 @@ public class LatexCommandArgumentInsertHandler implements InsertHandler<LookupEl
         else if (object instanceof LatexMathCommand) {
             insertMathCommand((LatexMathCommand)object, insertionContext);
         }
-        else if (object instanceof LatexNoMathCommand) {
-            insertNoMathCommand((LatexNoMathCommand)object, insertionContext);
+        else if (object instanceof LatexRegularCommand) {
+            insertNoMathCommand((LatexRegularCommand)object, insertionContext);
         }
     }
 
@@ -59,7 +59,7 @@ public class LatexCommandArgumentInsertHandler implements InsertHandler<LookupEl
         }
     }
 
-    private void insertNoMathCommand(LatexNoMathCommand noMathCommand, InsertionContext context) {
+    private void insertNoMathCommand(LatexRegularCommand noMathCommand, InsertionContext context) {
         if (noMathCommand.autoInsertRequired()) {
             insert(context, noMathCommand.getCommand());
         }

--- a/src/nl/rubensten/texifyidea/gutter/LatexNavigationGutter.java
+++ b/src/nl/rubensten/texifyidea/gutter/LatexNavigationGutter.java
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import nl.rubensten.texifyidea.TexifyIcons;
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
+import nl.rubensten.texifyidea.lang.LatexRegularCommand;
 import nl.rubensten.texifyidea.lang.RequiredFileArgument;
 import nl.rubensten.texifyidea.psi.LatexCommands;
 import nl.rubensten.texifyidea.psi.LatexRequiredParam;
@@ -53,9 +53,9 @@ public class LatexNavigationGutter extends RelatedItemLineMarkerProvider {
         boolean ignoreFileArgument = "\\RequirePackage".equals(fullCommand) ||
                 "\\usepackage".equals(fullCommand);
 
-        // Fetch the corresponding LatexNoMathCommand object.
+        // Fetch the corresponding LatexRegularCommand object.
         String commandName = fullCommand.substring(1);
-        LatexNoMathCommand commandHuh = LatexNoMathCommand.get(commandName);
+        LatexRegularCommand commandHuh = LatexRegularCommand.get(commandName);
         if (commandHuh == null && !ignoreFileArgument) {
             return;
         }

--- a/src/nl/rubensten/texifyidea/insight/LatexParameterInfoHandler.kt
+++ b/src/nl/rubensten/texifyidea/insight/LatexParameterInfoHandler.kt
@@ -5,13 +5,13 @@ import com.intellij.lang.parameterInfo.*
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ArrayUtil
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand
+import nl.rubensten.texifyidea.lang.LatexRegularCommand
 import nl.rubensten.texifyidea.psi.LatexCommands
 
 /**
  * @author Sten Wessel
  */
-class LatexParameterInfoHandler : ParameterInfoHandler<LatexCommands, LatexNoMathCommand> {
+class LatexParameterInfoHandler : ParameterInfoHandler<LatexCommands, LatexRegularCommand> {
 
     private fun findLatexCommand(file: PsiFile, offset: Int): LatexCommands? {
         val element = file.findElementAt(offset)
@@ -24,7 +24,7 @@ class LatexParameterInfoHandler : ParameterInfoHandler<LatexCommands, LatexNoMat
         return ArrayUtil.EMPTY_OBJECT_ARRAY
     }
 
-    override fun getParametersForDocumentation(p: LatexNoMathCommand, context: ParameterInfoContext): Array<Any>? {
+    override fun getParametersForDocumentation(p: LatexRegularCommand, context: ParameterInfoContext): Array<Any>? {
         return ArrayUtil.EMPTY_OBJECT_ARRAY
     }
 
@@ -33,7 +33,7 @@ class LatexParameterInfoHandler : ParameterInfoHandler<LatexCommands, LatexNoMat
     }
 
     override fun showParameterInfo(element: LatexCommands, context: CreateParameterInfoContext) {
-        val commandHuh = LatexNoMathCommand[element.commandToken.text.substring(1)] ?: return
+        val commandHuh = LatexRegularCommand[element.commandToken.text.substring(1)] ?: return
 
         context.itemsToShow = arrayOf<Any>(commandHuh)
         context.showHint(element, element.textOffset, this)
@@ -51,7 +51,7 @@ class LatexParameterInfoHandler : ParameterInfoHandler<LatexCommands, LatexNoMat
 
     override fun tracksParameterIndex() = true
 
-    override fun updateUI(cmd: LatexNoMathCommand?, context: ParameterInfoUIContext) {
+    override fun updateUI(cmd: LatexRegularCommand?, context: ParameterInfoUIContext) {
         if (cmd == null) {
             context.isUIComponentEnabled = false
             return

--- a/src/nl/rubensten/texifyidea/inspections/LatexSpellcheckingStrategy.kt
+++ b/src/nl/rubensten/texifyidea/inspections/LatexSpellcheckingStrategy.kt
@@ -9,7 +9,7 @@ import nl.rubensten.texifyidea.LatexLanguage
 import nl.rubensten.texifyidea.lang.Argument
 import nl.rubensten.texifyidea.lang.Argument.Type
 import nl.rubensten.texifyidea.lang.LatexMathCommand
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand
+import nl.rubensten.texifyidea.lang.LatexRegularCommand
 import nl.rubensten.texifyidea.psi.*
 import nl.rubensten.texifyidea.util.hasParent
 
@@ -71,7 +71,7 @@ class LatexSpellcheckingStrategy : SpellcheckingStrategy() {
     }
 
     private fun getArguments(commandName: String): Array<out Argument>? {
-        val cmdHuh = LatexNoMathCommand[commandName]
+        val cmdHuh = LatexRegularCommand[commandName]
         if (cmdHuh != null) {
             return cmdHuh.arguments
         }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexUnicodeInspection.java
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexUnicodeInspection.java
@@ -19,7 +19,7 @@ import nl.rubensten.texifyidea.inspections.TexifyInspectionBase;
 import nl.rubensten.texifyidea.lang.Diacritic;
 import nl.rubensten.texifyidea.lang.LatexCommand;
 import nl.rubensten.texifyidea.lang.LatexMathCommand;
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand;
+import nl.rubensten.texifyidea.lang.LatexRegularCommand;
 import nl.rubensten.texifyidea.psi.LatexMathEnvironment;
 import nl.rubensten.texifyidea.psi.LatexNormalText;
 import nl.rubensten.texifyidea.util.Magic;
@@ -172,7 +172,7 @@ public class LatexUnicodeInspection extends TexifyInspectionBase {
      * <p>
      * The following attempts are made, in order, to determine a suitable replacement: <ol> <li> The
      * character is matched against the <em>display</em> attribute of either {@link
-     * LatexNoMathCommand} or {@link LatexMathCommand} (where appropiate). When there is a match,
+     * LatexRegularCommand} or {@link LatexMathCommand} (where appropiate). When there is a match,
      * the corresponding command is used as replacement. </li> <li> The character is decomposed to
      * separate combining marks (see also <a href="http://unicode.org/reports/tr15/">Unicode</a>).
      * An attempt is made to match the combining sequence against LaTeX character diacritical
@@ -208,7 +208,7 @@ public class LatexUnicodeInspection extends TexifyInspectionBase {
             // Try to find in lookup for special command
             String replacement;
             LatexCommand command = inMathMode ? LatexMathCommand.findByDisplay(c) :
-                    LatexNoMathCommand.findByDisplay(c);
+                    LatexRegularCommand.findByDisplay(c);
 
             // Replace with found command or with standard substitution
             if (command != null) {

--- a/src/nl/rubensten/texifyidea/lang/LatexCommand.kt
+++ b/src/nl/rubensten/texifyidea/lang/LatexCommand.kt
@@ -12,7 +12,7 @@ interface LatexCommand : Dependend {
     companion object {
 
         /**
-         * Looks up the given command name in all [LatexMathCommand]s and [LatexNoMathCommand]s.
+         * Looks up the given command name in all [LatexMathCommand]s and [LatexRegularCommand]s.
          *
          * @param commandName
          *          The command name to look up. Can start with or without `\`
@@ -24,7 +24,7 @@ interface LatexCommand : Dependend {
                 result = result.substring(1)
             }
 
-            return LatexMathCommand[result] ?: LatexNoMathCommand[result]
+            return LatexMathCommand[result] ?: LatexRegularCommand[result]
         }
 
         /**
@@ -40,7 +40,7 @@ interface LatexCommand : Dependend {
             return if (command.inMathContext()) {
                 LatexMathCommand[commandName]
             }
-            else LatexNoMathCommand[commandName]
+            else LatexRegularCommand[commandName]
         }
     }
 

--- a/src/nl/rubensten/texifyidea/lang/LatexMathCommand.kt
+++ b/src/nl/rubensten/texifyidea/lang/LatexMathCommand.kt
@@ -296,6 +296,7 @@ enum class LatexMathCommand(
     BIGUPLUS("biguplus", display = "⨄", collapse = true),
     BIGVEE("bigvee", display = "⋁", collapse = true),
     BIGWEDGE("bigwedge", display = "⋀", collapse = true),
+    BINOM("binom", "total".asRequired(), "sample".asRequired()),
     BOT("bot", display = "⟂", collapse = true),
     BRACEVERT("bracevert"),
     BREVE("breve", "a".asRequired()),
@@ -339,6 +340,8 @@ enum class LatexMathCommand(
     UNDERBRACE("underbrace", "text".asRequired()),
     UNDERLINE("underline", "text".asRequired()),
     VEC("vec", "a".asRequired()),
+    VEE("vee",  display = "⋁", collapse = true),
+    WEDGE("wedge", display = "⋀", collapse = true),
     WIDEHAT("widehat", "text".asRequired()),
     WIDETILDE("widetilde", "text".asRequired());
 

--- a/src/nl/rubensten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/rubensten/texifyidea/lang/LatexRegularCommand.kt
@@ -12,7 +12,7 @@ import nl.rubensten.texifyidea.lang.Package.Companion.ULEM
 /**
  * @author Sten Wessel
  */
-enum class LatexNoMathCommand(
+enum class LatexRegularCommand(
         override val command: String,
         override vararg val arguments: Argument = emptyArray(),
         override val dependency: Package = DEFAULT,
@@ -308,6 +308,14 @@ enum class LatexNoMathCommand(
     RENEWCOMMAND_STAR("renewcommand*", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "def".asRequired(Type.TEXT)),
     NEWENVIRONMENT("newenvironment", "name".asRequired(), "args".asOptional(), "default".asOptional(), "begdef".asRequired(Type.TEXT), "enddef".asRequired(Type.TEXT)),
     RENEWENVIRONMENT("renewenvironment", "name".asRequired(), "args".asOptional(), "default".asOptional(), "begdef".asRequired(Type.TEXT), "enddef".asRequired(Type.TEXT)),
+    NEWDOCUMENTCOMMAND("NewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
+    RENEWDOCUMENTCOMMAND("RenewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
+    PROVIDEDOCUMENTCOMMAND("ProvideDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
+    DECLAREDOCUMENTCOMMAND("DeclareDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
+    NEWDOCUMENTENVIRONMENT("NewDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
+    RENEWDOCUMENTENVIRONMENT("RenewDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
+    PROVIDEDOCUMENTENVIRONMENT("ProvideDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
+    DECLAREDOCUMENTENVIRONMENT("DeclareDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
 
     /**
      * Natbib citations
@@ -339,11 +347,11 @@ enum class LatexNoMathCommand(
 
     companion object {
 
-        private val lookup = HashMap<String, LatexNoMathCommand>()
-        private val lookupDisplay = HashMap<String, LatexNoMathCommand>()
+        private val lookup = HashMap<String, LatexRegularCommand>()
+        private val lookupDisplay = HashMap<String, LatexRegularCommand>()
 
         init {
-            for (command in LatexNoMathCommand.values()) {
+            for (command in LatexRegularCommand.values()) {
                 lookup[command.command] = command
                 if (command.display != null) {
                     lookupDisplay.putIfAbsent(command.display!!, command)

--- a/src/nl/rubensten/texifyidea/lang/LatexRegularCommand.kt
+++ b/src/nl/rubensten/texifyidea/lang/LatexRegularCommand.kt
@@ -308,14 +308,18 @@ enum class LatexRegularCommand(
     RENEWCOMMAND_STAR("renewcommand*", "cmd".asRequired(), "args".asOptional(), "default".asOptional(), "def".asRequired(Type.TEXT)),
     NEWENVIRONMENT("newenvironment", "name".asRequired(), "args".asOptional(), "default".asOptional(), "begdef".asRequired(Type.TEXT), "enddef".asRequired(Type.TEXT)),
     RENEWENVIRONMENT("renewenvironment", "name".asRequired(), "args".asOptional(), "default".asOptional(), "begdef".asRequired(Type.TEXT), "enddef".asRequired(Type.TEXT)),
-    NEWDOCUMENTCOMMAND("NewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
-    RENEWDOCUMENTCOMMAND("RenewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
-    PROVIDEDOCUMENTCOMMAND("ProvideDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
-    DECLAREDOCUMENTCOMMAND("DeclareDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired()),
-    NEWDOCUMENTENVIRONMENT("NewDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
-    RENEWDOCUMENTENVIRONMENT("RenewDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
-    PROVIDEDOCUMENTENVIRONMENT("ProvideDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
-    DECLAREDOCUMENTENVIRONMENT("DeclareDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired()),
+
+    /**
+     * Xparse definitions.
+     */
+    NEWDOCUMENTCOMMAND("NewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired(), dependency = Package.XPARSE),
+    RENEWDOCUMENTCOMMAND("RenewDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired(), dependency = Package.XPARSE),
+    PROVIDEDOCUMENTCOMMAND("ProvideDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired(), dependency = Package.XPARSE),
+    DECLAREDOCUMENTCOMMAND("DeclareDocumentCommand", "name".asRequired(), "args spec".asRequired(), "code".asRequired(), dependency = Package.XPARSE),
+    NEWDOCUMENTENVIRONMENT("NewDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired(), dependency = Package.XPARSE),
+    RENEWDOCUMENTENVIRONMENT("RenewDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired(), dependency = Package.XPARSE),
+    PROVIDEDOCUMENTENVIRONMENT("ProvideDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired(), dependency = Package.XPARSE),
+    DECLAREDOCUMENTENVIRONMENT("DeclareDocumentEnvironment", "name".asRequired(), "args spec".asRequired(), "start code".asRequired(), "end code".asRequired(), dependency = Package.XPARSE),
 
     /**
      * Natbib citations

--- a/src/nl/rubensten/texifyidea/lang/Package.kt
+++ b/src/nl/rubensten/texifyidea/lang/Package.kt
@@ -27,6 +27,7 @@ open class Package @JvmOverloads constructor(
         @JvmField val BIBLATEX = Package("biblatex")
         @JvmField val LUACODE = Package("luacode")
         @JvmField val NATBIB = Package("natbib")
+        @JvmField val XPARSE = Package("xparse")
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/navigation/GotoCommandDefinitionSymbolContributor.kt
+++ b/src/nl/rubensten/texifyidea/navigation/GotoCommandDefinitionSymbolContributor.kt
@@ -1,0 +1,18 @@
+package nl.rubensten.texifyidea.navigation
+
+import com.intellij.openapi.project.Project
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.findCommandDefinitions
+import nl.rubensten.texifyidea.util.forcedFirstRequiredParameterAsCommand
+
+/**
+ * @author Ruben Schellekens
+ */
+class GotoCommandDefinitionSymbolContributor : TexifyGotoSymbolBase<LatexCommands>() {
+
+    override fun Project.findElements() = findCommandDefinitions()
+
+    override fun LatexCommands.extractName() = forcedFirstRequiredParameterAsCommand()?.name
+
+    override fun LatexCommands.createNavigationItem() = NavigationItemUtil.createCommandDefinitionNavigationItem(this)
+}

--- a/src/nl/rubensten/texifyidea/navigation/GotoEnvironmentDefinitionSymbolContributor.kt
+++ b/src/nl/rubensten/texifyidea/navigation/GotoEnvironmentDefinitionSymbolContributor.kt
@@ -1,0 +1,18 @@
+package nl.rubensten.texifyidea.navigation
+
+import com.intellij.openapi.project.Project
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.findEnvironmentDefinitions
+import nl.rubensten.texifyidea.util.requiredParameter
+
+/**
+ * @author Ruben Schellekens
+ */
+class GotoEnvironmentDefinitionSymbolContributor : TexifyGotoSymbolBase<LatexCommands>() {
+
+    override fun Project.findElements() = findEnvironmentDefinitions()
+
+    override fun LatexCommands.extractName() = requiredParameter(0)
+
+    override fun LatexCommands.createNavigationItem() = NavigationItemUtil.createEnvironmentDefinitionNavigationItem(this)
+}

--- a/src/nl/rubensten/texifyidea/navigation/GotoLabelSymbolContributor.kt
+++ b/src/nl/rubensten/texifyidea/navigation/GotoLabelSymbolContributor.kt
@@ -1,0 +1,18 @@
+package nl.rubensten.texifyidea.navigation
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import nl.rubensten.texifyidea.util.extractLabelName
+import nl.rubensten.texifyidea.util.findLabels
+
+/**
+ * @author Ruben Schellekens
+ */
+class GotoLabelSymbolContributor : TexifyGotoSymbolBase<PsiElement>() {
+
+    override fun Project.findElements() = findLabels()
+
+    override fun PsiElement.extractName() = extractLabelName()
+
+    override fun PsiElement.createNavigationItem() = NavigationItemUtil.createLabelNavigationItem(this)
+}

--- a/src/nl/rubensten/texifyidea/navigation/NavigationItemUtil.kt
+++ b/src/nl/rubensten/texifyidea/navigation/NavigationItemUtil.kt
@@ -1,0 +1,45 @@
+package nl.rubensten.texifyidea.navigation
+
+import com.intellij.navigation.NavigationItem
+import com.intellij.psi.PsiElement
+import com.intellij.util.xml.model.gotosymbol.GoToSymbolProvider
+import nl.rubensten.texifyidea.TexifyIcons
+import nl.rubensten.texifyidea.psi.BibtexId
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.Magic
+import nl.rubensten.texifyidea.util.forcedFirstRequiredParameterAsCommand
+import nl.rubensten.texifyidea.util.requiredParameter
+
+/**
+ * @author Ruben Schellekens
+ */
+object NavigationItemUtil {
+
+    @JvmStatic
+    fun createLabelNavigationItem(psiElement: PsiElement): NavigationItem? {
+        when (psiElement) {
+            is LatexCommands -> return GoToSymbolProvider.BaseNavigationItem(psiElement,
+                    psiElement.requiredParameter(0) ?: return null,
+                    if (psiElement.name in Magic.Command.labels) TexifyIcons.DOT_LABEL else TexifyIcons.DOT_BIB
+            )
+            is BibtexId -> return GoToSymbolProvider.BaseNavigationItem(psiElement,
+                    psiElement.name ?: return null,
+                    TexifyIcons.DOT_BIB
+            )
+        }
+
+        return null
+    }
+
+    @JvmStatic
+    fun createCommandDefinitionNavigationItem(psiElement: LatexCommands): NavigationItem? {
+        val defined = psiElement.forcedFirstRequiredParameterAsCommand() ?: return null
+        return GoToSymbolProvider.BaseNavigationItem(psiElement, defined.name ?: "", TexifyIcons.DOT_COMMAND)
+    }
+
+    @JvmStatic
+    fun createEnvironmentDefinitionNavigationItem(psiElement: LatexCommands): NavigationItem? {
+        val environmentName = psiElement.requiredParameter(0) ?: return null
+        return GoToSymbolProvider.BaseNavigationItem(psiElement, environmentName, TexifyIcons.DOT_ENVIRONMENT)
+    }
+}

--- a/src/nl/rubensten/texifyidea/navigation/TexifyGotoSymbolBase.kt
+++ b/src/nl/rubensten/texifyidea/navigation/TexifyGotoSymbolBase.kt
@@ -1,0 +1,45 @@
+package nl.rubensten.texifyidea.navigation
+
+import com.intellij.navigation.ChooseByNameContributor
+import com.intellij.navigation.NavigationItem
+import com.intellij.openapi.project.Project
+
+/**
+ * @author Ruben Schellekens
+ */
+abstract class TexifyGotoSymbolBase<T> : ChooseByNameContributor {
+
+    /**
+     * Finds all elements that can be found in 'Goto symbol'.
+     */
+    abstract fun Project.findElements(): Iterable<T>
+
+    /**
+     * Transforms the element into its visible and identifyable name.
+     * `null` when no name is available.
+     */
+    abstract fun T.extractName(): String?
+
+    /**
+     * Creates a navigation item from the given element.
+     * `null` when no navigation item could be created.
+     */
+    abstract fun T.createNavigationItem(): NavigationItem?
+
+    override fun getItemsByName(name: String?, pattern: String?, project: Project?, includeNonProjectItems: Boolean): Array<NavigationItem> {
+        val elements = project?.findElements() ?: return emptyArray()
+        return elements.asSequence()
+                .map { it to it.extractName() }
+                .filter { (_, definedName) ->
+                    definedName == name || (pattern != null && (definedName ?: "").contains(pattern, ignoreCase = true))
+                }
+                .mapNotNull { (psi, _) -> psi.createNavigationItem() }
+                .toList()
+                .toTypedArray()
+    }
+
+    override fun getNames(project: Project?, includeNonProjectItems: Boolean): Array<String> {
+        val elements = project?.findElements() ?: return emptyArray()
+        return elements.mapNotNull { it.extractName() }.toTypedArray()
+    }
+}

--- a/src/nl/rubensten/texifyidea/structure/latex/LatexLabelPresentation.kt
+++ b/src/nl/rubensten/texifyidea/structure/latex/LatexLabelPresentation.kt
@@ -4,26 +4,20 @@ import com.intellij.navigation.ItemPresentation
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import nl.rubensten.texifyidea.TexifyIcons
 import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.Magic
+import nl.rubensten.texifyidea.util.requiredParameter
 
 /**
  * @author Ruben Schellekens
  */
-class LatexLabelPresentation(labelCommand: LatexCommands) : ItemPresentation {
+class LatexLabelPresentation(val labelCommand: LatexCommands) : ItemPresentation {
 
-    private val labelName: String
     private val locationString: String
 
     init {
-        if (labelCommand.commandToken.text != "\\label") {
+        if (labelCommand.commandToken.text !in Magic.Command.labels) {
             throw IllegalArgumentException("command is no \\label-command")
         }
-
-        // Get label name.
-        val required = labelCommand.requiredParameters
-        if (required.isEmpty()) {
-            throw IllegalArgumentException("\\label has no label name")
-        }
-        this.labelName = required[0]
 
         // Location string.
         val manager = FileDocumentManager.getInstance()
@@ -32,7 +26,7 @@ class LatexLabelPresentation(labelCommand: LatexCommands) : ItemPresentation {
         this.locationString = labelCommand.containingFile.name + ":" + line
     }
 
-    override fun getPresentableText() = labelName
+    override fun getPresentableText() = labelCommand.requiredParameter(0) ?: ""
 
     override fun getLocationString() = locationString
 

--- a/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -131,10 +131,9 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
         }
 
         // Add command definitions.
-        addFromCommand(treeElements, commands, "\\newcommand")
-        addFromCommand(treeElements, commands, "\\DeclareMathOperator")
-        addFromCommand(treeElements, commands, "\\let")
-        addFromCommand(treeElements, commands, "\\def")
+        Magic.Command.commandDefinitions.forEach {
+            addFromCommand(treeElements, commands, it)
+        }
 
         // Add label definitions.
         addFromCommand(treeElements, commands, "\\label")
@@ -205,16 +204,10 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
     private fun addFromCommand(treeElements: MutableList<TreeElement>, commands: List<LatexCommands>,
                                commandName: String) {
         for (cmd in commands) {
-            if (cmd.commandToken.text != commandName) {
-                continue
-            }
+            if (cmd.commandToken.text != commandName) continue
+            val definedCommand = cmd.forcedFirstRequiredParameterAsCommand() ?: continue
 
-            val required = cmd.requiredParameters
-            if (commandName == "\\newcommand" && required.isEmpty()) {
-                continue
-            }
-
-            val element = LatexStructureViewCommandElement.newCommand(cmd)
+            val element = LatexStructureViewCommandElement.newCommand(definedCommand)
             if (element != null) {
                 treeElements.add(element)
             }

--- a/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -14,7 +14,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 import nl.rubensten.texifyidea.file.*
 import nl.rubensten.texifyidea.index.LatexCommandsIndex
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand
+import nl.rubensten.texifyidea.lang.LatexRegularCommand
 import nl.rubensten.texifyidea.lang.RequiredFileArgument
 import nl.rubensten.texifyidea.psi.LatexCommands
 import nl.rubensten.texifyidea.psi.LatexTypes
@@ -177,7 +177,7 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
             }
 
             // Find file
-            val latexCommandHuh = LatexNoMathCommand[name.substring(1)] ?: continue
+            val latexCommandHuh = LatexRegularCommand[name.substring(1)] ?: continue
             val argument = latexCommandHuh
                     .getArgumentsOf(RequiredFileArgument::class.java)[0]
 

--- a/src/nl/rubensten/texifyidea/util/Commands.kt
+++ b/src/nl/rubensten/texifyidea/util/Commands.kt
@@ -1,0 +1,16 @@
+package nl.rubensten.texifyidea.util
+
+import com.intellij.openapi.project.Project
+import nl.rubensten.texifyidea.index.LatexDefinitionIndex
+import nl.rubensten.texifyidea.psi.LatexCommands
+
+/**
+ * Finds all defined commands within the project.
+ *
+ * @return The found commands.
+ */
+fun Project.findCommandDefinitions(): Collection<LatexCommands> {
+    return LatexDefinitionIndex.getItems(this).filter {
+        it.name in Magic.Command.commandDefinitions
+    }
+}

--- a/src/nl/rubensten/texifyidea/util/Environments.kt
+++ b/src/nl/rubensten/texifyidea/util/Environments.kt
@@ -1,0 +1,16 @@
+package nl.rubensten.texifyidea.util
+
+import com.intellij.openapi.project.Project
+import nl.rubensten.texifyidea.index.LatexDefinitionIndex
+import nl.rubensten.texifyidea.psi.LatexCommands
+
+/**
+ * Finds all environemnt definition commands within the project.
+ *
+ * @return The found definition commands.
+ */
+fun Project.findEnvironmentDefinitions(): Collection<LatexCommands> {
+    return LatexDefinitionIndex.getItems(this).filter {
+        it.name in Magic.Command.environmentDefinitions
+    }
+}

--- a/src/nl/rubensten/texifyidea/util/Labels.kt
+++ b/src/nl/rubensten/texifyidea/util/Labels.kt
@@ -1,6 +1,5 @@
 package nl.rubensten.texifyidea.util
 
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -8,7 +7,6 @@ import nl.rubensten.texifyidea.index.BibtexIdIndex
 import nl.rubensten.texifyidea.index.LatexCommandsIndex
 import nl.rubensten.texifyidea.psi.BibtexId
 import nl.rubensten.texifyidea.psi.LatexCommands
-import kotlin.streams.toList
 
 /**
  * Finds all the defined labels in the fileset of the file.
@@ -92,16 +90,13 @@ fun Project.findLabels(): Collection<PsiElement> {
  *         Key to match the label with.
  * @return A list of matched label commands.
  */
-fun Project.findLabels(key: String?): Collection<PsiElement> = findLabels().parallelStream()
-        .filter { command ->
-            if (command is LatexCommands) {
-                val parameters = runReadAction { command.requiredParameters }
-                parameters.isNotEmpty() && key != null && key == parameters.firstOrNull()
+fun Project.findLabels(key: String?): Collection<PsiElement> = findLabels().filter { it.extractLabelName() == key }
 
-            }
-            else if (command is BibtexId) {
-                key == command.name
-            }
-            else false
-        }
-        .toList()
+/**
+ * Extracts the label name from the PsiElement given that the PsiElement represents a label.
+ */
+fun PsiElement.extractLabelName(): String = when (this) {
+    is BibtexId -> idName()
+    is LatexCommands -> requiredParameter(0) ?: ""
+    else -> text
+}

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -149,7 +149,10 @@ object Magic {
                 "\\let",
                 "\\def",
                 "\\DeclareMathOperator",
-                "\\newif"
+                "\\newif",
+                "\\NewDocumentCommand",
+                "\\ProvidesDocumentCommand",
+                "\\DeclareDocumentCommand"
         )
 
         /**
@@ -160,7 +163,12 @@ object Magic {
         /**
          * All commands that define new environments.
          */
-        @JvmField val environmentDefinitions = hashSetOf("\\newenvironment")
+        @JvmField val environmentDefinitions = hashSetOf(
+                "\\newenvironment",
+                "\\NewDocumentEnvironment",
+                "\\ProvidesDocumentEnvironment",
+                "\\DeclareDocumentEnvironment"
+        )
 
         /**
          * All commands that define stuff like classes, environments, and definitions.
@@ -188,7 +196,13 @@ object Magic {
                 "\\overline", "\\paragraph", "\\part", "\\renewcommand", "\\section", "\\setcounter",
                 "\\sout", "\\subparagraph", "\\subsection", "\\subsubsection", "\\textbf",
                 "\\textit", "\\textsc", "\\textsl", "\\texttt", "\\underline", "\\[", "\\]",
-                "\\newenvironment", "\\bibitem"
+                "\\newenvironment", "\\bibitem",
+                "\\NewDocumentCommand",
+                "\\ProvidesDocumentCommand",
+                "\\DeclareDocumentCommand",
+                "\\NewDocumentEnvironment",
+                "\\ProvidesDocumentEnvironment",
+                "\\DeclareDocumentEnvironment"
         )
 
         /**

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -151,7 +151,7 @@ object Magic {
                 "\\DeclareMathOperator",
                 "\\newif",
                 "\\NewDocumentCommand",
-                "\\ProvidesDocumentCommand",
+                "\\ProvideDocumentCommand",
                 "\\DeclareDocumentCommand"
         )
 
@@ -166,7 +166,7 @@ object Magic {
         @JvmField val environmentDefinitions = hashSetOf(
                 "\\newenvironment",
                 "\\NewDocumentEnvironment",
-                "\\ProvidesDocumentEnvironment",
+                "\\ProvideDocumentEnvironment",
                 "\\DeclareDocumentEnvironment"
         )
 
@@ -198,10 +198,10 @@ object Magic {
                 "\\textit", "\\textsc", "\\textsl", "\\texttt", "\\underline", "\\[", "\\]",
                 "\\newenvironment", "\\bibitem",
                 "\\NewDocumentCommand",
-                "\\ProvidesDocumentCommand",
+                "\\ProvideDocumentCommand",
                 "\\DeclareDocumentCommand",
                 "\\NewDocumentEnvironment",
-                "\\ProvidesDocumentEnvironment",
+                "\\ProvideDocumentEnvironment",
                 "\\DeclareDocumentEnvironment"
         )
 

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -128,6 +128,11 @@ object Magic {
         @JvmField val bibliographyItems = setOf("\\bibitem")
 
         /**
+         * All label definition commands.
+         */
+        @JvmField val labels = setOf("\\label")
+
+        /**
          * All math operators without a leading slash.
          */
         @JvmField val slashlessMathOperators = hashSetOf(
@@ -139,15 +144,28 @@ object Magic {
         /**
          * All commands that define new commands.
          */
-        @JvmField val definitions = hashSetOf(
+        @JvmField val commandDefinitions = hashSetOf(
                 "\\newcommand",
                 "\\let",
                 "\\def",
                 "\\DeclareMathOperator",
-                "\\newenvironment",
-                "\\newif",
-                "\\ProvidesClass"
+                "\\newif"
         )
+
+        /**
+         * All commands that define new documentclasses.
+         */
+        @JvmField val classDefinitions = hashSetOf("\\ProvidesClass")
+
+        /**
+         * All commands that define new environments.
+         */
+        @JvmField val environmentDefinitions = hashSetOf("\\newenvironment")
+
+        /**
+         * All commands that define stuff like classes, environments, and definitions.
+         */
+        @JvmField val definitions = commandDefinitions + classDefinitions + environmentDefinitions
 
         /**
          * All commands that are able to redefine other commands.

--- a/src/nl/rubensten/texifyidea/util/Psi.kt
+++ b/src/nl/rubensten/texifyidea/util/Psi.kt
@@ -5,7 +5,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import nl.rubensten.texifyidea.index.LatexIncludesIndex
 import nl.rubensten.texifyidea.lang.DefaultEnvironment
 import nl.rubensten.texifyidea.lang.Environment
 import nl.rubensten.texifyidea.psi.*

--- a/src/nl/rubensten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiCommands.kt
@@ -54,7 +54,7 @@ fun LatexCommands?.isEnvironmentDefinition(): Boolean {
 /**
  * Get the command that gets defined by a definition (`\let` or `\def` command).
  */
-fun LatexCommands.definitionCommand(): LatexCommands? = nextCommand()
+fun LatexCommands.definitionCommand(): LatexCommands? = forcedFirstRequiredParameterAsCommand()
 
 /**
  * Checks whether the command has a star or not.

--- a/src/nl/rubensten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiCommands.kt
@@ -4,7 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import nl.rubensten.texifyidea.lang.LatexMathCommand
-import nl.rubensten.texifyidea.lang.LatexNoMathCommand
+import nl.rubensten.texifyidea.lang.LatexRegularCommand
 import nl.rubensten.texifyidea.psi.*
 
 /**
@@ -100,7 +100,7 @@ fun LatexCommands.definedCommandName() = when (name) {
  */
 fun LatexCommands.isKnown(): Boolean {
     val name = name?.substring(1) ?: ""
-    return LatexNoMathCommand[name] != null || LatexMathCommand[name] != null
+    return LatexRegularCommand[name] != null || LatexMathCommand[name] != null
 }
 
 /**


### PR DESCRIPTION
Various updates to the built in commands. Depends on PR #789.

#### Additions
- Added support for `xparse` definition commands.
- Added `\binom`, `\vee`, and `\wedge` to the autocomplete.

#### Changes
- `LatexNoMathCommand` is now called `LatexRegularCommand`.

#### Backwards incompatible changes
