### PR TITLE
Add bibtex inspections for addbibresource

### DIFF
--- a/src/nl/rubensten/texifyidea/completion/handlers/FileNameInsertionHandler.kt
+++ b/src/nl/rubensten/texifyidea/completion/handlers/FileNameInsertionHandler.kt
@@ -22,7 +22,7 @@ open class FileNameInsertionHandler : InsertHandler<LookupElement> {
         val normalTextWord = file.findElementAt(offset) ?: return
         val command = normalTextWord.parentOfType(LatexCommands::class) ?: return
 
-        if (command.name != "\\include" && command.name != "\\bibliography") {
+        if (command.name != "\\include" && command.name != "\\bibliography" && command.name != "\\addbibresource") {
             return
         }
 

--- a/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -32,7 +32,7 @@ open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
         val descriptors = descriptorList()
 
         LatexIncludesIndex.getItemsInFileSet(file).asSequence()
-                .filter { it.name == "\\bibliography" }
+                .filter { it.name == "\\bibliography" || it.name == "\\addbibresource"}
                 .groupBy { it.requiredParameters.getOrNull(0) }
                 .filter { it.key != null && it.value.size > 1 }
                 .flatMap { it.value }
@@ -64,7 +64,7 @@ open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
             val file = command.containingFile
 
             file.commandsInFileSet().asSequence()
-                    .filter { it.name == "\\bibliography" && it.requiredParameter(0) == command.requiredParameter(0) && it != command }
+                    .filter { (it.name == "\\bibliography" || it.name == "\\addbibresource") && it.requiredParameter(0) == command.requiredParameter(0) && it != command }
                     .forEach {
                         it.delete()
                     }

--- a/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/bibtex/BibtexDuplicateBibliographyInspection.kt
@@ -32,7 +32,7 @@ open class BibtexDuplicateBibliographyInspection : TexifyInspectionBase() {
         val descriptors = descriptorList()
 
         LatexIncludesIndex.getItemsInFileSet(file).asSequence()
-                .filter { it.name == "\\bibliography" || it.name == "\\addbibresource"}
+                .filter { it.name == "\\bibliography" || it.name == "\\addbibresource" }
                 .groupBy { it.requiredParameters.getOrNull(0) }
                 .filter { it.key != null && it.value.size > 1 }
                 .flatMap { it.value }

--- a/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -167,7 +167,7 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
         for (cmd in commands) {
             val name = cmd.commandToken.text
             if (name != "\\include" && name != "\\includeonly" && name != "\\input"
-                    && name != "\\bibliography") {
+                    && name != "\\bibliography" && name != "\\addbibresource") {
                 continue
             }
 

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -158,7 +158,7 @@ object Magic {
          * All commands that include other files.
          */
         @JvmField val includes = hashSetOf(
-                "\\includeonly", "\\include", "\\input", "\\bibliography", "\\RequirePackage", "\\usepackage"
+                "\\includeonly", "\\include", "\\input", "\\bibliography", "\\addbibresource", "\\RequirePackage", "\\usepackage"
         )
 
         /**
@@ -188,6 +188,7 @@ object Magic {
                 "\\include" to hashSetOf("tex"),
                 "\\includeonly" to hashSetOf("tex"),
                 "\\bibliography" to hashSetOf("bib"),
+                "\\addbibresource" to hashSetOf("bib"),
                 "\\RequirePackage" to hashSetOf("sty"),
                 "\\usepackage" to hashSetOf("sty")
         )


### PR DESCRIPTION
Fixes #803 (MWE also here)

**Changes**
Some inspections and checks for `\bibliography` command are now also triggered for `\addbibresource`.

Note that `\addbibresource` requires the `.bib` extension (but there is no inspection for that yet), see the [docs](http://ctan.triasinformatica.nl/macros/latex/contrib/biblatex/doc/biblatex.pdf) section 3.7.1.