### PR TITLE
Add support for texliveonfly compiler script

### DIFF
--- a/src/nl/rubensten/texifyidea/run/LatexCompiler.kt
+++ b/src/nl/rubensten/texifyidea/run/LatexCompiler.kt
@@ -96,21 +96,13 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
             val command = mutableListOf(runConfig.compilerPath ?: "texliveonfly")
 
             // texliveonfly is a Python script which calls other compilers (by default pdflatex), main feature is downloading packages automatically
-            // commands can be passed to those compilers with the arguments flag
-            command.add("--arguments='")
-
-            // The arguments that will be passed on.
-            // -interaction=nonstopmode and -synctex=1 are on by default
-            command.add("--output-format=${runConfig.outputFormat.name.toLowerCase()}")
-            command.add("--file-line-error")
-
-            // It does not make sense to run this on Windows because there MikTeX already can automatically download packages
+            // commands can be passed to those compilers with the arguments flag, however apparently IntelliJ cannot handle quotes so we cannot pass multiple arguments to pdflatex.
+            // Fortunately, -synctex=1 and -interaction=nonstopmode are on by default in texliveonfly
+            // Since adding one will work without any quotes, we choose the output directory.
             if (runConfig.hasOutputDirectories()) {
-                command.add("--output-directory=${moduleRoot.path}/out'")
+                command.add("--arguments=--output-directory=${moduleRoot.path}/out")
             }
 
-            // Close the compiler arguments
-            command.add("'")
             return command
         }
     };


### PR DESCRIPTION
#### Additions

* Added Texliveonfly to the compiler options

[texliveonfly](https://tex.stackexchange.com/questions/110501/auto-package-download-for-texlive/463842#463842) is a package for TeX Live, it is a Python script which downloads package dependencies automatically (by looking at the log for missing packages and then downloading them). It requires tlmgr to be executable without sudo. 

I couldn't find a way to handle quotes in passing arguments with the command line handler, i.e. `texliveonfly --arguments="--output-format=pdf --file-line-error" main.tex` works in the terminal but I didn't manage to let IJ execute this properly. But it works like this anyway.
