### PR TITLE
Configure inverse search correctly when no 32-bit Java is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,6 @@ where the files `introduction.tex` and `example-theorems.tex` contain just the c
 \end{theorem}
 ```
 
-#### SumatraPDF inverse search: _Error launching IDEA. No JVM installation found_
-* Please make sure you have a 32-bit JDK installed. This solved the issue before ([#104](https://github.com/Ruben-Sten/TeXiFy-IDEA/issues/104)). If installing a 32-bit JDK is resolving the problem for you, please report this on the issue tracker.
-
 #### The Equation Preview does not work
 
 Make sure you have installed the dependencies, instructions are in the [Equation Preview](#equation-preview) section.

--- a/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -10,6 +10,10 @@ import nl.rubensten.texifyidea.TexifyIcons
 import nl.rubensten.texifyidea.run.isSumatraAvailable
 import javax.swing.JLabel
 import javax.swing.SwingConstants
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.PlatformUtils
+
+
 
 /**
  * Sets up inverse search integration with SumatraPDF.
@@ -40,8 +44,20 @@ open class ConfigureInverseSearchAction : AnAction(
             addCancelAction()
             setOkOperation {
                 val path = PathManager.getBinPath()
-                val name = ApplicationNamesInfo.getInstance().scriptName
-                Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" \\\"\\\" --line %l \\\"%f\\\"\"")
+                var name = ApplicationNamesInfo.getInstance().scriptName
+
+                // If we can find a 64-bits Java, then we can start (the equivalent of) idea64.exe since that will use the 64-bits Java
+                // see issue 104 and https://github.com/Ruben-Sten/TeXiFy-IDEA/issues/809
+                // If we find a 32-bits Java or nothing at all, we will keep (the equivalent of) idea.exe which is the default
+                if (System.getProperty("sun.arch.data.model") == "64") {
+                    // We will assume that since the user is using a 64-bit IDEA that name64 exists, this is at least true for idea64.exe and pycharm64.exe on Windows
+                    name += "64"
+                    // We also remove an extra "" because it opens an empty IDEA instance when present
+                    Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" --line %l \\\"%f\\\"\"")
+                } else {
+                    Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" \\\"\\\" --line %l \\\"%f\\\"\"")
+                }
+
                 dialogWrapper.close(0)
             }
 

--- a/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -10,9 +10,6 @@ import nl.rubensten.texifyidea.TexifyIcons
 import nl.rubensten.texifyidea.run.isSumatraAvailable
 import javax.swing.JLabel
 import javax.swing.SwingConstants
-import com.intellij.openapi.util.SystemInfo
-import com.intellij.util.PlatformUtils
-
 
 
 /**

--- a/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -51,7 +51,8 @@ open class ConfigureInverseSearchAction : AnAction(
                     name += "64"
                     // We also remove an extra "" because it opens an empty IDEA instance when present
                     Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" --line %l \\\"%f\\\"\"")
-                } else {
+                }
+                else {
                     Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" \\\"\\\" --line %l \\\"%f\\\"\"")
                 }
 

--- a/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
+++ b/src/nl/rubensten/texifyidea/action/sumatra/ConfigureInverseSearchAction.kt
@@ -40,7 +40,7 @@ open class ConfigureInverseSearchAction : AnAction(
             addCancelAction()
             setOkOperation {
                 val path = PathManager.getBinPath()
-                val name = ApplicationNamesInfo.getInstance().defaultLauncherName
+                val name = ApplicationNamesInfo.getInstance().scriptName
                 Runtime.getRuntime().exec("cmd.exe /c start SumatraPDF -inverse-search \"\\\"$path\\$name.exe\\\" \\\"\\\" --line %l \\\"%f\\\"\"")
                 dialogWrapper.close(0)
             }


### PR DESCRIPTION
Fixes #809 and actually fixes #104 properly now as well, the way this is implemented is that we check the system property `sun.arch.data.model`, and if it returns 64 I think we can be sure a 64-bit java is installed. That means that we can use (the equivalent of) `idea64.exe`, because that uses a 64-bit java (see for example [this SO answer](https://stackoverflow.com/a/33010846/4126843)). Otherwise we use `idea.exe` like before.

I tested this when I didn't have a 32-bit JDK installed separately (previously this was a situation which produced the error in #104 ). Also tested it after I uninstalled my 64-bit JDK, however the system property still returned 64 and idea64.exe still worked, I guess IDEA has a 64-bit JRE bundled or something. So in practice I think we are replacing idea.exe by idea64.exe for most people. *Please test yourself that inverse search still works* (after reconfiguring) but I think it will work.
