### PR TITLE
Fix label not shown in structure view

### DIFF
--- a/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -136,10 +136,10 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
         }
 
         // Add label definitions.
-        addFromCommand(treeElements, commands, "\\label")
+        addLabelsFromCommand(treeElements, commands, "\\label")
 
         // Add bibitem definitions.
-        addFromCommand(treeElements, commands, "\\bibitem")
+        addLabelsFromCommand(treeElements, commands, "\\bibitem")
 
         return treeElements.toTypedArray()
     }
@@ -206,11 +206,16 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
         for (cmd in commands) {
             if (cmd.commandToken.text != commandName) continue
             val definedCommand = cmd.forcedFirstRequiredParameterAsCommand() ?: continue
+            val element = LatexStructureViewCommandElement.newCommand(definedCommand) ?: continue
+            treeElements.add(element)
+        }
+    }
 
-            val element = LatexStructureViewCommandElement.newCommand(definedCommand)
-            if (element != null) {
-                treeElements.add(element)
-            }
+    private fun addLabelsFromCommand(treeElements: MutableList<TreeElement>, commands: List<LatexCommands>,
+                                     commandName: String) {
+        commands.filter { it.commandToken.text == commandName }.forEach {
+            val element = LatexStructureViewCommandElement.newCommand(it) ?: return@forEach
+            treeElements.add(element)
         }
     }
 

--- a/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
+++ b/src/nl/rubensten/texifyidea/structure/latex/LatexStructureViewElement.kt
@@ -136,10 +136,10 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
         }
 
         // Add label definitions.
-        addLabelsFromCommand(treeElements, commands, "\\label")
+        addFromCommand(treeElements, commands, "\\label")
 
         // Add bibitem definitions.
-        addLabelsFromCommand(treeElements, commands, "\\bibitem")
+        addFromCommand(treeElements, commands, "\\bibitem")
 
         return treeElements.toTypedArray()
     }
@@ -205,16 +205,7 @@ class LatexStructureViewElement(private val element: PsiElement) : StructureView
                                commandName: String) {
         for (cmd in commands) {
             if (cmd.commandToken.text != commandName) continue
-            val definedCommand = cmd.forcedFirstRequiredParameterAsCommand() ?: continue
-            val element = LatexStructureViewCommandElement.newCommand(definedCommand) ?: continue
-            treeElements.add(element)
-        }
-    }
-
-    private fun addLabelsFromCommand(treeElements: MutableList<TreeElement>, commands: List<LatexCommands>,
-                                     commandName: String) {
-        commands.filter { it.commandToken.text == commandName }.forEach {
-            val element = LatexStructureViewCommandElement.newCommand(it) ?: return@forEach
+            val element = LatexStructureViewCommandElement.newCommand(cmd) ?: continue
             treeElements.add(element)
         }
     }


### PR DESCRIPTION
#### Changes
Changed adding commands to display ```\bibitem``` and ```\label``` again.
Now userdefined commands displayed on first load, not only the icon.

#### Problem:
The problem started in 322304a41f667c911db4d457113fd69c138238b2. I could not find an Issue or PR related to this commit. Could anyone explain why these changes were made? I couldn't figure it out, not even by looking into previous commits in this branch.
Especially the change to pass the first parameter casted as a command to ```LatexStructureViewCommandElement.newCommand()``` and not the command itself  which worked properly beffore.