### PR TITLE
Add Gradle task to upload to the alpha channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 out
 build
 *iml
+gradle/credentials.properties

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 out
 build
 *iml
+credentials.properties

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 out
 build
 *iml
-credentials.properties

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 out
 build
 *iml
-gradle/credentials.properties

--- a/README.md
+++ b/README.md
@@ -200,7 +200,10 @@ The alpha channel contains the latest build with the latest features available, 
 It is used for testing features before they are released in the stable channel, so alpha versions of the plugin may be more unstable.
 
 #### Subscribing to the alpha channel
-You can subscribe to the alpha channel by going to Settings | Plugins | gear icon | Manage Plugin Repositories | plus icon, then use the url https://plugins.jetbrains.com/plugins/alpha/list
+
+* Uninstall the plugin
+* Subscribe to the alpha channel by going to Settings | Plugins | gear icon | Manage Plugin Repositories | plus icon, then use the url https://plugins.jetbrains.com/plugins/alpha/list
+* Install the plugin by going to Marketplace and searching for `TeXiFy-IDEA`, you should see the version next to the name is the alpha version.
 
 ## <a name="build-from-source">Building from source using IntelliJ</a>
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ The current implementation of the Equation Preview was contributed by Sergei Izm
 * Add both `C:\Program Files\Inkscape` and `C:\Program Files\pdf2svg` to your PATH environment variable, for example by searching for Environment Variables on your computer, clicking 'Edit the system environment variables', clicking 'Environment Variables', and under System variables find the one named Path, edit it and insert the paths here. Make sure the paths are separated by a `;`.
 * Reboot your system.
 
+## Alpha channel: subscribing to the very latest features
+
+This plugin also has an alpha channel besides the default stable channel.
+The alpha channel contains the latest build with the latest features available, and is updated much more frequently than the stable channel.
+It is used for testing features before they are released in the stable channel, so alpha versions of the plugin may be more unstable.
+
+#### Subscribing to the alpha channel
+You can subscribe to the alpha channel by going to Settings | Plugins | gear icon | Manage Plugin Repositories | plus icon, then use the url https://plugins.jetbrains.com/plugins/alpha/list
+
 ## <a name="build-from-source">Building from source using IntelliJ</a>
 
 #### I know what I'm doing

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ It is used for testing features before they are released in the stable channel, 
 
 #### Subscribing to the alpha channel
 
+More detailed information is at https://www.jetbrains.com/help/idea/managing-plugins.html#repos but we will quickly summarize the steps.
 * Uninstall the plugin
 * Subscribe to the alpha channel by going to Settings | Plugins | gear icon | Manage Plugin Repositories | plus icon, then use the url https://plugins.jetbrains.com/plugins/alpha/list
 * Install the plugin by going to Marketplace and searching for `TeXiFy-IDEA`, you should see the version next to the name is the alpha version.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-// Include credentials to publish the plugin
-apply from: "gradle/credentials.properties"
-
 // Include the Gradle plugins which help building everything.
 // Supersedes the use of 'buildscript' block and 'apply plugin:'
 plugins {
@@ -13,6 +10,9 @@ plugins {
     // Plugin which can update Gradle dependencies, use the help/useLatestVersions task.
     id 'se.patrikerdes.use-latest-versions' version '0.2.7'
 }
+
+// Include credentials to publish the plugin
+apply from: "gradle/credentials.properties"
 
 group 'nl.rubensten'
 version '0.6.3'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+// Include credentials to publish the plugin
+apply from: "gradle/credentials.properties"
+
 // Include the Gradle plugins which help building everything.
 // Supersedes the use of 'buildscript' block and 'apply plugin:'
 plugins {
@@ -127,4 +130,14 @@ test {
 patchPluginXml {
     sinceBuild '141.*'
     untilBuild ''
+}
+
+// Allow publishing to the Jetbrains repo via a Gradle task
+// This requires to put your Jetbrains username and password in a gradle/credentials.properties file, see http://www.jetbrains.org/intellij/sdk/docs/tutorials/build_system/deployment.html for more details
+publishPlugin {
+    username intellijPublishUsername
+    password intellijPublishPassword
+    // We need to set the intellij.publish.channel property according to the tutorial
+    // It is documented here that it is the same as below: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/README.md#publishing-dsl
+    channels ['alpha']
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,6 @@ plugins {
     id 'se.patrikerdes.use-latest-versions' version '0.2.7'
 }
 
-// Include credentials to publish the plugin
-apply from: "gradle/credentials.properties"
-
 group 'nl.rubensten'
 version '0.6.3'
 
@@ -135,9 +132,15 @@ patchPluginXml {
 // Allow publishing to the Jetbrains repo via a Gradle task
 // This requires to put your Jetbrains username and password in a gradle/credentials.properties file, see http://www.jetbrains.org/intellij/sdk/docs/tutorials/build_system/deployment.html for more details
 publishPlugin {
-    username intellijPublishUsername
-    password intellijPublishPassword
+    // Although apply from: "filename.properties" is the right way according to the IJ docs this is apparently deprecated since Gradle 2, so we have to work around that.
+    Properties credentialProperties = new Properties()
+    InputStream inputStream = new FileInputStream("gradle/credentials.properties")
+    credentialProperties.load(inputStream)
+    inputStream.close()
+
+    username credentialProperties['intellijPublishUsername']
+    password credentialProperties['intellijPublishPassword']
     // We need to set the intellij.publish.channel property according to the tutorial
     // It is documented here that it is the same as below: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/README.md#publishing-dsl
-    channels ['alpha']
+    channels 'alpha'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,7 @@ publishPlugin {
 
     username credentialProperties['intellijPublishUsername']
     password credentialProperties['intellijPublishPassword']
+    
     // We need to set the intellij.publish.channel property according to the tutorial
     // It is documented here that it is the same as below: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/README.md#publishing-dsl
     channels 'alpha'

--- a/gradle/credentials.properties
+++ b/gradle/credentials.properties
@@ -1,0 +1,3 @@
+# Remember, do not check in your credentials to version control!
+intellijPublishUsername="myusername"
+intellijPublishPassword="mypassword"

--- a/gradle/credentials.properties
+++ b/gradle/credentials.properties
@@ -1,4 +1,4 @@
 # Remember, do not check in your credentials to version control!
 # You can execute git update-index --assume-unchanged gradle/credentials.properties to ignore changes.
-intellijPublishUsername="myusername"
-intellijPublishPassword="mypassword"
+intellijPublishUsername=myusername
+intellijPublishPassword=mypassword

--- a/gradle/credentials.properties
+++ b/gradle/credentials.properties
@@ -1,3 +1,4 @@
 # Remember, do not check in your credentials to version control!
+# You can execute git update-index --assume-unchanged gradle/credentials.properties to ignore changes.
 intellijPublishUsername="myusername"
 intellijPublishPassword="mypassword"


### PR DESCRIPTION
#### Additions

* Added Gradle task
* Added instructions how to subscribe

You can view alpha releases at https://plugins.jetbrains.com/plugin/9473-texify-idea (I renamed the latest one to alpha instead of nightly, I think it will be approved next week)
Note I had to add the .properties file otherwise the Gradle build fails.

Apparently I averaged about one alpha build per week in the last four months, I think I'll keep around that average for the coming time.
