### PR TITLE
Added 'Goto symbol' support for section markers.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -348,6 +348,7 @@
         <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoLabelSymbolContributor"/>
         <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoCommandDefinitionSymbolContributor"/>
         <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoEnvironmentDefinitionSymbolContributor"/>
+        <gotoSymbolContributor implementation="nl.rubensten.texifyidea.navigation.GotoSectionDefinitionSymbolContributor"/>
 
         <!-- Line markers -->
         <codeInsight.lineMarkerProvider language="Latex" implementationClass="nl.rubensten.texifyidea.gutter.LatexNavigationGutter"/>

--- a/src/nl/rubensten/texifyidea/navigation/GotoSectionDefinitionSymbolContributor.kt
+++ b/src/nl/rubensten/texifyidea/navigation/GotoSectionDefinitionSymbolContributor.kt
@@ -1,0 +1,18 @@
+package nl.rubensten.texifyidea.navigation
+
+import com.intellij.openapi.project.Project
+import nl.rubensten.texifyidea.psi.LatexCommands
+import nl.rubensten.texifyidea.util.findSectionMarkers
+import nl.rubensten.texifyidea.util.requiredParameter
+
+/**
+ * @author Ruben Schellekens
+ */
+class GotoSectionDefinitionSymbolContributor : TexifyGotoSymbolBase<LatexCommands>() {
+
+    override fun Project.findElements() = findSectionMarkers()
+
+    override fun LatexCommands.extractName() = (this as? LatexCommands)?.requiredParameter(0)
+
+    override fun LatexCommands.createNavigationItem() = NavigationItemUtil.createSectionMarkerNavigationItem(this)
+}

--- a/src/nl/rubensten/texifyidea/navigation/GotoSectionDefinitionSymbolContributor.kt
+++ b/src/nl/rubensten/texifyidea/navigation/GotoSectionDefinitionSymbolContributor.kt
@@ -12,7 +12,7 @@ class GotoSectionDefinitionSymbolContributor : TexifyGotoSymbolBase<LatexCommand
 
     override fun Project.findElements() = findSectionMarkers()
 
-    override fun LatexCommands.extractName() = (this as? LatexCommands)?.requiredParameter(0)
+    override fun LatexCommands.extractName() = requiredParameter(0)
 
     override fun LatexCommands.createNavigationItem() = NavigationItemUtil.createSectionMarkerNavigationItem(this)
 }

--- a/src/nl/rubensten/texifyidea/navigation/NavigationItemUtil.kt
+++ b/src/nl/rubensten/texifyidea/navigation/NavigationItemUtil.kt
@@ -42,4 +42,20 @@ object NavigationItemUtil {
         val environmentName = psiElement.requiredParameter(0) ?: return null
         return GoToSymbolProvider.BaseNavigationItem(psiElement, environmentName, TexifyIcons.DOT_ENVIRONMENT)
     }
+
+    @JvmStatic
+    fun createSectionMarkerNavigationItem(psiElement: LatexCommands): NavigationItem? {
+        val sectionName = psiElement.requiredParameter(0) ?: return null
+        val icon = when (psiElement.commandToken.text) {
+            "\\part" -> TexifyIcons.DOT_PART
+            "\\chapter" -> TexifyIcons.DOT_CHAPTER
+            "\\subsection" -> TexifyIcons.DOT_SUBSECTION
+            "\\subsubsection" -> TexifyIcons.DOT_SUBSUBSECTION
+            "\\paragraph" -> TexifyIcons.DOT_PARAGRAPH
+            "\\subparagraph" -> TexifyIcons.DOT_SUBPARAGRAPH
+            // Also catches \section.
+            else -> TexifyIcons.DOT_SECTION
+        }
+        return GoToSymbolProvider.BaseNavigationItem(psiElement, sectionName, icon)
+    }
 }

--- a/src/nl/rubensten/texifyidea/util/Labels.kt
+++ b/src/nl/rubensten/texifyidea/util/Labels.kt
@@ -100,3 +100,12 @@ fun PsiElement.extractLabelName(): String = when (this) {
     is LatexCommands -> requiredParameter(0) ?: ""
     else -> text
 }
+
+/**
+ * Finds all section marker commands (as defined in [Magic.Command.sectionMarkers]) in the project.
+ *
+ * @return A list containing all the section marker [LatexCommands].
+ */
+fun Project.findSectionMarkers() = LatexCommandsIndex.getItems(this).filter {
+    it.commandToken.text in Magic.Command.sectionMarkers
+}

--- a/src/nl/rubensten/texifyidea/util/PsiCommands.kt
+++ b/src/nl/rubensten/texifyidea/util/PsiCommands.kt
@@ -104,7 +104,7 @@ fun LatexCommands.isKnown(): Boolean {
 }
 
 /**
- * Get the `index+1`th required parameter of the command.
+ * Get the text contents of the `index+1`th required parameter of the command.
  *
  * @throws IllegalArgumentException When the index is negative.
  */


### PR DESCRIPTION
Continuation of #771 and #789.

#### Additions
* Goto symbol functionality also works for section markers now.

#### Pictures
![image](https://user-images.githubusercontent.com/17410729/52913445-94045e00-32be-11e9-985e-5e4dae0ac369.png)

