### PR TITLE
Word count only analyses LaTeX files

### DIFF
--- a/src/nl/rubensten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/rubensten/texifyidea/action/analysis/WordCountAction.kt
@@ -9,7 +9,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import nl.rubensten.texifyidea.TexifyIcons
-import nl.rubensten.texifyidea.file.LatexFileType
 import nl.rubensten.texifyidea.psi.*
 import nl.rubensten.texifyidea.util.*
 import java.util.regex.Pattern
@@ -104,7 +103,7 @@ open class WordCountAction : AnAction(
      */
     private fun countWords(baseFile: PsiFile): Pair<Int, Int> {
         val fileSet = baseFile.referencedFileSet()
-                .filter { it.fileType == LatexFileType }
+                .filter { it.name.endsWith(".tex", ignoreCase = true) }
         val allNormalText = fileSet.flatMap { it.childrenOfType(LatexNormalText::class) }
 
         val bibliographies = baseFile.childrenOfType(LatexEnvironment::class)

--- a/src/nl/rubensten/texifyidea/action/analysis/WordCountAction.kt
+++ b/src/nl/rubensten/texifyidea/action/analysis/WordCountAction.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiWhiteSpace
 import nl.rubensten.texifyidea.TexifyIcons
+import nl.rubensten.texifyidea.file.LatexFileType
 import nl.rubensten.texifyidea.psi.*
 import nl.rubensten.texifyidea.util.*
 import java.util.regex.Pattern
@@ -33,7 +34,7 @@ open class WordCountAction : AnAction(
                 "\\usepackage", "\\documentclass", "\\label", "\\linespread", "\\ref", "\\cite", "\\eqref", "\\nameref",
                 "\\autoref", "\\fullref", "\\pageref", "\\newcounter", "\\newcommand", "\\renewcommand",
                 "\\setcounter", "\\resizebox", "\\includegraphics", "\\include", "\\input", "\\refstepcounter",
-                "\\counterwithins", "\\RequirePackage"
+                "\\counterwithins", "\\RequirePackage", "\\bibliography", "\\bibliographystyle"
         )
 
         /**
@@ -103,6 +104,7 @@ open class WordCountAction : AnAction(
      */
     private fun countWords(baseFile: PsiFile): Pair<Int, Int> {
         val fileSet = baseFile.referencedFileSet()
+                .filter { it.fileType == LatexFileType }
         val allNormalText = fileSet.flatMap { it.childrenOfType(LatexNormalText::class) }
 
         val bibliographies = baseFile.childrenOfType(LatexEnvironment::class)


### PR DESCRIPTION
Fixes #860.

#### Changes
- Word count only analyses LaTeX files now (ignores TikZ).
- Text in `\bibliography` and `\bibliographystyle` gets ignored.
