### PR TITLE
Fixed crash #861: LatexCiteBeforePeriod quickfix at the end of a file.

### DIFF
--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
@@ -29,7 +29,7 @@ open class LatexCiteBeforePeriodInspection : TexifyRegexInspection(
         val cite = file.findElementAt(replacementRange.endInclusive + 3)?.parentOfType(LatexCommands::class) ?: return
         val char = groups[0]
 
-        if (document[cite.endOffset()] != char) {
+        if (cite.endOffset() >= document.textLength || document[cite.endOffset()] != char) {
             document.insertString(cite.endOffset(), char)
         }
 


### PR DESCRIPTION
Fixes #861.

## Changes
- Quick fix no longer tries to access non-existent characters with index larger than the document length.