### PR TITLE
Improve performance by failing fast if regex doesn't match

### DIFF
--- a/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
+++ b/src/nl/rubensten/texifyidea/editor/UpDownAutoBracket.kt
@@ -51,6 +51,12 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
             "\\label", "\\bibitem" -> return Result.CONTINUE
         }
 
+        // Only insert when a valid symbol has been typed.
+        val afterSymbol = c.toString()
+        if (!insertOnly.matches(afterSymbol)) {
+            return Result.CONTINUE
+        }
+
         // Insert squiggly brackets.
         if (element is LatexNormalText) {
             handleNormalText(element, editor, c)
@@ -125,12 +131,6 @@ open class UpDownAutoBracket : TypedHandlerDelegate() {
         val relative = caret.offset - normalText.textOffset
 
         if (relative < 3 || text.length < relative - 1) {
-            return
-        }
-
-        // Only insert when a valid symbol has been typed.
-        val afterSymbol = char.toString()
-        if (!insertOnly.matches(afterSymbol)) {
             return
         }
 


### PR DESCRIPTION
Resolves #868 

I think the functionality here is the same, but please point out if I've missed something that required this regex check to be where it was.

When I tested, this does fix the issue with the opening backslash (though it's still as slow when you type the next character - need to spend some more time looking at UpDownAutoBracket).