### PR TITLE
Added the \newtheorem command to the auto complete

### DIFF
--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -170,6 +170,7 @@ object Magic {
          */
         @JvmField val environmentDefinitions = hashSetOf(
                 "\\newenvironment",
+                "\\newtheorem",
                 "\\NewDocumentEnvironment",
                 "\\ProvideDocumentEnvironment",
                 "\\DeclareDocumentEnvironment"


### PR DESCRIPTION
Added the `\newtheorem` command to the list of commands that define a new environment (from the list #260).

Note that `\newtheorem` does not require the `amsthm` package.
