### PR TITLE
Ignore cref and autoref for nbsp inspection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+dist: trusty
 
 # Make the gradle wrapper executable
 before_install: chmod +x gradlew

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexNonBreakingSpaceInspection.kt
@@ -30,7 +30,7 @@ open class LatexNonBreakingSpaceInspection : TexifyInspectionBase() {
         /**
          * All commands that should not have a forced breaking space.
          */
-        val IGNORED_COMMANDS = setOf("\\citet", "\\citet*", "\\Citet", "\\Citet*")
+        val IGNORED_COMMANDS = setOf("\\citet", "\\citet*", "\\Citet", "\\Citet*", "\\cref", "\\cpageref", "\\autoref")
     }
 
     override fun getInspectionGroup() = InsightGroup.LATEX


### PR DESCRIPTION
Hey,
great project, thank you so much! :tada: 
I've been bothered by a few false alarms and this is my attempt to fix a few of them. :wink:

The commands `\cref`, `\cpageref` and `\autoref` automatically produce the name of the section/figure/etc..
Therefore there is no need for a non-breaking space before them.
