### PR TITLE
Fix all the Fix All fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+dist: trusty
 
 # Make the gradle wrapper executable
 before_install: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,9 @@ intellij {
 }
 
 test {
+    // Enable JUnit 5 (Gradle 4.6+).
+    useJUnitPlatform()
+    
     // Always run tests, even when nothing changed
 //    dependsOn 'cleanTest'
     // Show test results

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -132,8 +132,6 @@ abstract class TexifyRegexInspection(
             val replacementRanges = arrayListOf<IntRange>()
             val replacements = arrayListOf<String>()
 
-            val groups = groupFetcher(matcher)
-
             // For each pattern, just save the replacement location and value
             while (matcher.find()) {
                 // Pre-checks.
@@ -168,7 +166,7 @@ abstract class TexifyRegexInspection(
                                 quickFixName(matcher),
                                 replacements,
                                 replacementRanges,
-                                groups,
+                                listOf(),
                                 this::applyFixes
                         )
                 )

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -321,7 +321,7 @@ abstract class TexifyRegexInspection(
     /**
      * @author Ruben Schellekens
      */
-    private class RegexFixes(
+    open class RegexFixes(
             val fixName: String,
             val replacements: List<String>,
             val replacementRanges: List<IntRange>,

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -9,10 +9,8 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import nl.rubensten.texifyidea.insight.InsightGroup
-import nl.rubensten.texifyidea.util.document
-import nl.rubensten.texifyidea.util.hasParent
-import nl.rubensten.texifyidea.util.inMathContext
-import nl.rubensten.texifyidea.util.isComment
+import nl.rubensten.texifyidea.lang.Package
+import nl.rubensten.texifyidea.util.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import kotlin.reflect.jvm.internal.impl.utils.SmartList
@@ -114,47 +112,99 @@ abstract class TexifyRegexInspection(
     override fun checkContext(element: PsiElement) = true
 
     override fun inspectFile(file: PsiFile, manager: InspectionManager, isOntheFly: Boolean): MutableList<ProblemDescriptor> {
-        val descriptors = SmartList<ProblemDescriptor>()
-
         // Find all patterns.
         val text = file.text
         val matcher = pattern.matcher(text)
-        while (matcher.find()) {
-            // Pre-checks.
-            if (cancelIf(matcher, file)) {
-                continue
+
+
+        // todo
+        if (!isOntheFly && runForWholeFile()) {
+            // todo
+            val replacementRanges = arrayListOf<IntRange>()
+            val replacements = arrayListOf<String>()
+
+            // Then the user is doing a 'fix all problems in file': because we are inspecting the file without doing it on the fly
+            // Find all patterns.
+            while (matcher.find()) {
+                // Pre-checks.
+                if (cancelIf(matcher, file)) {
+                    continue
+                }
+
+                val groups = groupFetcher(matcher)
+                val textRange = highlightRange(matcher)
+                val range = replacementRange(matcher)
+                val error = errorMessage(matcher)
+                val quickFix = quickFixName(matcher)
+                val replacementContent = replacement(matcher, file)
+
+                // Correct context.
+                val element = file.findElementAt(matcher.start()) ?: continue
+                if (!checkContext(matcher, element)) {
+                    continue
+                }
+
+                replacementRanges.add(range)
+                replacements.add(replacementContent)
             }
 
-            val groups = groupFetcher(matcher)
-            val textRange = highlightRange(matcher)
-            val range = replacementRange(matcher)
-            val error = errorMessage(matcher)
-            val quickFix = quickFixName(matcher)
-            val replacementContent = replacement(matcher, file)
-
-            // Correct context.
-            val element = file.findElementAt(matcher.start()) ?: continue
-            if (!checkContext(matcher, element)) {
-                continue
-            }
-
-            descriptors.add(manager.createProblemDescriptor(
+            val problemDescriptor = manager.createProblemDescriptor(
                     file,
-                    textRange,
-                    error,
+                    null as TextRange?,
+                    errorMessage(matcher),
                     highlight,
                     isOntheFly,
                     RegexFix(
-                            quickFix,
-                            replacementContent,
-                            range,
-                            groups,
-                            this::applyFix
+                            quickFixName(matcher),
+                            replacements,
+                            replacementRanges,
+                            groupFetcher(matcher),
+                            this::applyFixes
                     )
-            ))
-        }
+                    )
 
-        return descriptors
+            return mutableListOf(problemDescriptor)
+
+        } else {
+            val descriptors = SmartList<ProblemDescriptor>()
+
+            while (matcher.find()) {
+                // Pre-checks.
+                if (cancelIf(matcher, file)) {
+                    continue
+                }
+
+                val groups = groupFetcher(matcher)
+                val textRange = highlightRange(matcher)
+                val range = replacementRange(matcher)
+                val error = errorMessage(matcher)
+                val quickFix = quickFixName(matcher)
+                val replacementContent = replacement(matcher, file)
+
+                // Correct context.
+                val element = file.findElementAt(matcher.start()) ?: continue
+                if (!checkContext(matcher, element)) {
+                    continue
+                }
+
+                descriptors.add(manager.createProblemDescriptor(
+                        file,
+                        textRange,
+                        error,
+                        highlight,
+                        isOntheFly,
+                        RegexFix(
+                                quickFix,
+                                arrayListOf(replacementContent),
+                                arrayListOf(range),
+                                groups,
+                                this::applyFixes
+                        )
+                ))
+            }
+
+            return descriptors
+        }
     }
 
     /**
@@ -174,12 +224,41 @@ abstract class TexifyRegexInspection(
 
     /**
      * Replaces all text in the replacementRange by the correct replacement.
+     *
+     * @param groups todo
      */
     open fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>) {
         val file = descriptor.psiElement as PsiFile
         val document = file.document() ?: return
 
         document.replaceString(replacementRange.start, replacementRange.endInclusive, replacement)
+
+    }
+
+    /**
+     * Replaces all text for all replacementRanges by the correct replacements.
+     *
+     * todo now inspections cannot override applyfix
+     */
+    open fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<String>) {
+        assert(replacementRanges.size == replacements.size)
+
+        var accumulatedDisplacement = 0
+
+        for (i in 0 until replacements.size) {
+            val replacementRange = replacementRanges[i]
+            val replacement = replacements[i]
+
+            val file = descriptor.psiElement as PsiFile
+            val document = file.document() ?: return
+
+            document.replaceString(replacementRange.start + accumulatedDisplacement, replacementRange.endInclusive + accumulatedDisplacement, replacement)
+
+            accumulatedDisplacement += replacement.length - (replacementRange.endInclusive - replacementRange.start)
+        }
+
+        val file = descriptor.psiElement.containingFile ?: return
+        file.insertUsepackage(Package.AMSSYMB)
     }
 
     /**
@@ -187,16 +266,16 @@ abstract class TexifyRegexInspection(
      */
     private class RegexFix(
             val fixName: String,
-            val replacement: String,
-            val replacementRange: IntRange,
+            val replacements: List<String>,
+            val replacementRanges: List<IntRange>,
             val groups: List<String>,
-            val fixFunction: (Project, ProblemDescriptor, IntRange, String, List<String>) -> Unit
+            val fixFunction: (Project, ProblemDescriptor, List<IntRange>, List<String>, List<String>) -> Unit
     ) : LocalQuickFix {
 
         override fun getFamilyName(): String = fixName
 
         override fun applyFix(project: Project, problemDescriptor: ProblemDescriptor) {
-            fixFunction(project, problemDescriptor, replacementRange, replacement, groups)
+            fixFunction(project, problemDescriptor, replacementRanges, replacements, groups)
         }
     }
 }

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -24,7 +24,7 @@ abstract class TexifyRegexInspection(
         val inspectionDisplayName: String,
 
         /**
-         * The short name of the inspection (same name as the html info file.
+         * The short name of the inspection (same name as the html info file).
          */
         val myInspectionId: String,
 
@@ -287,6 +287,18 @@ abstract class TexifyRegexInspection(
                         replacements: List<String>,
                         groups: List<List<String>>
     ) {
+        val fixFunction = { replacementRange: IntRange, replacement: String, group: List<String> -> applyFix(descriptor, replacementRange, replacement, group) }
+        applyFixes(fixFunction, replacementRanges, replacements, groups)
+    }
+
+    /**
+     * See [applyFixes].
+     */
+    open fun applyFixes(fixFunction: (IntRange, String, List<String>) -> Int,
+                        replacementRanges: List<IntRange>,
+                        replacements: List<String>,
+                        groups: List<List<String>>
+    ) {
         require(replacementRanges.size == replacements.size) { "The number of replacement values has to equal the number of ranges of those replacements." }
 
         // Remember how much a replacement changed the locations of the fixes still to be applied.
@@ -299,7 +311,7 @@ abstract class TexifyRegexInspection(
             val replacement = replacements[i]
 
             val newRange = IntRange(replacementRange.start + accumulatedDisplacement, replacementRange.endInclusive + accumulatedDisplacement)
-            val replacementLength = applyFix(descriptor, newRange, replacement, groups[i])
+            val replacementLength = fixFunction(newRange, replacement, groups[i])
 
             // Fix the locations of the next fixes
             accumulatedDisplacement += replacementLength

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -118,7 +118,6 @@ abstract class TexifyRegexInspection(
         val text = file.text
         val matcher = pattern.matcher(text)
 
-
         // The file is inspected 'not on the fly' when the 'fix all problems in file' menu is used.
         // If that is the case and we need to run the inspection for the
         // whole file at once, we create only one problem descriptor for
@@ -177,11 +176,13 @@ abstract class TexifyRegexInspection(
                 )
 
                 return mutableListOf(problemDescriptor)
-            } else {
+            }
+            else {
                 return mutableListOf()
             }
 
-        } else {
+        }
+        else {
             val descriptors = SmartList<ProblemDescriptor>()
 
             while (matcher.find()) {

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -15,7 +15,6 @@ import nl.rubensten.texifyidea.util.inMathContext
 import nl.rubensten.texifyidea.util.isComment
 import java.util.regex.Matcher
 import java.util.regex.Pattern
-import kotlin.reflect.jvm.internal.impl.utils.SmartList
 
 /**
  * @author Ruben Schellekens
@@ -166,7 +165,7 @@ abstract class TexifyRegexInspection(
             replacements.add(replacementContent)
         }
 
-        if (replacementRanges.size > 0) {
+        if (replacementRanges.isNotEmpty()) {
 
             // We cannot give one TextRange because there are multiple,
             // but it does not matter since the user won't see this anyway.
@@ -197,7 +196,7 @@ abstract class TexifyRegexInspection(
      * Inspect the file and create a list of all problem descriptors.
      */
     private fun inspectFileOnTheFly(file: PsiFile, manager: InspectionManager, matcher: Matcher): MutableList<ProblemDescriptor> {
-        val descriptors = SmartList<ProblemDescriptor>()
+        val descriptors = descriptorList()
 
         while (matcher.find()) {
             // Pre-checks.
@@ -263,7 +262,8 @@ abstract class TexifyRegexInspection(
     /**
      * Replaces all text in the replacementRange by the correct replacement.
      *
-     * @return The total increase in document length, e.g. if << is replaced by \ll and \usepackage{amsmath} is added then the total increase is 3 + 20 - 2.
+     * @return The total increase in document length, e.g. if << is replaced by
+     * \ll and \usepackage{amsmath} is added then the total increase is 3 + 20 - 2.
      */
     open fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
         val file = descriptor.psiElement as PsiFile
@@ -283,8 +283,13 @@ abstract class TexifyRegexInspection(
      *
      * @param groups Regex groups as matched by the regex matcher.
      */
-    open fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>) {
-        assert(replacementRanges.size == replacements.size)
+    open fun applyFixes(project: Project,
+                        descriptor: ProblemDescriptor,
+                        replacementRanges: List<IntRange>,
+                        replacements: List<String>,
+                        groups: List<List<String>>
+    ) {
+        require(replacementRanges.size == replacements.size) { "The number of replacement values has to equal the number of ranges of those replacements." }
 
         // Remember how much a replacement changed the locations of the fixes still to be applied.
         // This is cumulative, but may be negative.

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -138,7 +138,8 @@ abstract class TexifyRegexInspection(
         val replacements = arrayListOf<String>()
         val groups = arrayListOf<List<String>>()
 
-        val quickFixName = quickFixName(matcher)
+        var quickFixName = ""
+        var errorMessage = ""
 
         // For each pattern, just save the replacement location and value
         // We use the fact that the matcher finds issues in increasing order when applying fixes
@@ -152,6 +153,11 @@ abstract class TexifyRegexInspection(
 
             val range = replacementRange(matcher)
             val replacementContent = replacement(matcher, file)
+
+            // Just take the last error/name even if it may not apply to all problems at once
+            // (they may each have a different error message) because we have to choose only one for the one problem descriptor.
+            errorMessage = errorMessage(matcher)
+            quickFixName = quickFixName(matcher)
 
             // Correct context.
             val element = file.findElementAt(matcher.start()) ?: continue
@@ -170,7 +176,7 @@ abstract class TexifyRegexInspection(
             val problemDescriptor = manager.createProblemDescriptor(
                     file,
                     null as TextRange?,
-                    errorMessage(matcher),
+                    errorMessage,
                     highlight,
                     false,
                     RegexFixes(
@@ -322,7 +328,7 @@ abstract class TexifyRegexInspection(
      * @author Ruben Schellekens
      */
     open class RegexFixes(
-            val fixName: String,
+            private val fixName: String,
             val replacements: List<String>,
             val replacementRanges: List<IntRange>,
             val groups: List<List<String>>,

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -232,7 +232,6 @@ abstract class TexifyRegexInspection(
         val document = file.document() ?: return
 
         document.replaceString(replacementRange.start, replacementRange.endInclusive, replacement)
-
     }
 
     /**
@@ -256,9 +255,6 @@ abstract class TexifyRegexInspection(
 
             accumulatedDisplacement += replacement.length - (replacementRange.endInclusive - replacementRange.start)
         }
-
-        val file = descriptor.psiElement.containingFile ?: return
-        file.insertUsepackage(Package.AMSSYMB)
     }
 
     /**

--- a/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/TexifyRegexInspection.kt
@@ -273,7 +273,7 @@ abstract class TexifyRegexInspection(
         val file = descriptor.psiElement as PsiFile
         val document = file.document() ?: return 0
 
-        document.replaceString(replacementRange.start, replacementRange.endInclusive, replacement)
+        document.replaceString(replacementRange.first, replacementRange.last, replacement)
 
         return replacement.length - replacementRange.length
     }
@@ -288,10 +288,11 @@ abstract class TexifyRegexInspection(
      * @param groups Regex groups as matched by the regex matcher.
      * @param replacementRanges These replacement ranges have to be ordered increasingly and have to be non-overlapping.
      */
-    open fun applyFixes(descriptor: ProblemDescriptor,
-                        replacementRanges: List<IntRange>,
-                        replacements: List<String>,
-                        groups: List<List<String>>
+    open fun applyFixes(
+            descriptor: ProblemDescriptor,
+            replacementRanges: List<IntRange>,
+            replacements: List<String>,
+            groups: List<List<String>>
     ) {
         val fixFunction = { replacementRange: IntRange, replacement: String, group: List<String> -> applyFix(descriptor, replacementRange, replacement, group) }
         applyFixes(fixFunction, replacementRanges, replacements, groups)
@@ -300,10 +301,11 @@ abstract class TexifyRegexInspection(
     /**
      * See [applyFixes].
      */
-    open fun applyFixes(fixFunction: (IntRange, String, List<String>) -> Int,
-                        replacementRanges: List<IntRange>,
-                        replacements: List<String>,
-                        groups: List<List<String>>
+    open fun applyFixes(
+            fixFunction: (IntRange, String, List<String>) -> Int,
+            replacementRanges: List<IntRange>,
+            replacements: List<String>,
+            groups: List<List<String>>
     ) {
         require(replacementRanges.size == replacements.size) { "The number of replacement values has to equal the number of ranges of those replacements." }
 
@@ -316,7 +318,7 @@ abstract class TexifyRegexInspection(
             val replacementRange = replacementRanges[i]
             val replacement = replacements[i]
 
-            val newRange = IntRange(replacementRange.start + accumulatedDisplacement, replacementRange.endInclusive + accumulatedDisplacement)
+            val newRange = IntRange(replacementRange.first + accumulatedDisplacement, replacementRange.last + accumulatedDisplacement)
             val replacementLength = fixFunction(newRange, replacement, groups[i])
 
             // Fix the locations of the next fixes

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
@@ -23,20 +23,22 @@ open class LatexCiteBeforePeriodInspection : TexifyRegexInspection(
         groupFetcher = { listOf(it.group(1)) }
 ) {
 
-    override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<String>) {
-        for (i in 0 until replacements.size) {
-            val replacementRange = replacementRanges[i]
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
 
-            val file = descriptor.psiElement.containingFile
-            val document = file.document() ?: return
-            val cite = file.findElementAt(replacementRange.endInclusive + 3)?.parentOfType(LatexCommands::class) ?: return
-            val char = groups[0]
+        val file = descriptor.psiElement.containingFile
+        val document = file.document() ?: return 0
+        val cite = file.findElementAt(replacementRange.endInclusive + 3)?.parentOfType(LatexCommands::class) ?: return 0
 
-            if (cite.endOffset() >= document.textLength || document[cite.endOffset()] != char) {
-                document.insertString(cite.endOffset(), char)
-            }
+        // Find the interpunction character (the first regex group) in order to move it after the cite
+        val char = groups[0]
+
+        if (cite.endOffset() >= document.textLength || document[cite.endOffset()] != char) {
+            document.insertString(cite.endOffset(), char)
         }
 
-        super.applyFixes(project, descriptor, replacementRanges, replacements, groups)
+        super.applyFix(project, descriptor, replacementRange, replacement, groups)
+
+        // The document length did not change, so the increase is 0
+        return 0
     }
 }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
@@ -1,7 +1,6 @@
 package nl.rubensten.texifyidea.inspections.latex
 
 import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.openapi.project.Project
 import nl.rubensten.texifyidea.inspections.TexifyRegexInspection
 import nl.rubensten.texifyidea.psi.LatexCommands
 import nl.rubensten.texifyidea.util.*
@@ -23,7 +22,7 @@ open class LatexCiteBeforePeriodInspection : TexifyRegexInspection(
         groupFetcher = { listOf(it.group(1)) }
 ) {
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
+    override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
 
         val file = descriptor.psiElement.containingFile
         val document = file.document() ?: return 0
@@ -36,7 +35,7 @@ open class LatexCiteBeforePeriodInspection : TexifyRegexInspection(
             document.insertString(cite.endOffset(), char)
         }
 
-        super.applyFix(project, descriptor, replacementRange, replacement, groups)
+        super.applyFix(descriptor, replacementRange, replacement, groups)
 
         // The document length did not change, so the increase is 0
         return 0

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexCiteBeforePeriodInspection.kt
@@ -23,16 +23,20 @@ open class LatexCiteBeforePeriodInspection : TexifyRegexInspection(
         groupFetcher = { listOf(it.group(1)) }
 ) {
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>) {
-        val file = descriptor.psiElement.containingFile
-        val document = file.document() ?: return
-        val cite = file.findElementAt(replacementRange.endInclusive + 3)?.parentOfType(LatexCommands::class) ?: return
-        val char = groups[0]
+    override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<String>) {
+        for (i in 0 until replacements.size) {
+            val replacementRange = replacementRanges[i]
 
-        if (cite.endOffset() >= document.textLength || document[cite.endOffset()] != char) {
-            document.insertString(cite.endOffset(), char)
+            val file = descriptor.psiElement.containingFile
+            val document = file.document() ?: return
+            val cite = file.findElementAt(replacementRange.endInclusive + 3)?.parentOfType(LatexCommands::class) ?: return
+            val char = groups[0]
+
+            if (cite.endOffset() >= document.textLength || document[cite.endOffset()] != char) {
+                document.insertString(cite.endOffset(), char)
+            }
         }
 
-        super.applyFix(project, descriptor, replacementRange, replacement, groups)
+        super.applyFixes(project, descriptor, replacementRanges, replacements, groups)
     }
 }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexEnDashInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexEnDashInspection.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiFile
 import nl.rubensten.texifyidea.inspections.TexifyRegexInspection
 import nl.rubensten.texifyidea.util.Magic
 import nl.rubensten.texifyidea.util.document
+import nl.rubensten.texifyidea.util.length
 import nl.rubensten.texifyidea.util.toTextRange
 import java.util.regex.Pattern
 
@@ -33,6 +34,6 @@ open class LatexEnDashInspection : TexifyRegexInspection(
         val dashReplacement = "$start--$end"
         document.replaceString(replacementRange.start, replacementRange.endInclusive, dashReplacement)
 
-        return dashReplacement.length - (replacementRange.endInclusive - replacementRange.start)
+        return dashReplacement.length - replacementRange.length
     }
 }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexEnDashInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexEnDashInspection.kt
@@ -24,12 +24,15 @@ open class LatexEnDashInspection : TexifyRegexInspection(
         groupFetcher = { listOf(it.group(2), it.group(3)) }
 ) {
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>) {
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
         val file = descriptor.psiElement as PsiFile
-        val document = file.document() ?: return
+        val document = file.document() ?: return 0
         val start = groups[0]
         val end = groups[1]
 
-        document.replaceString(replacementRange.start, replacementRange.endInclusive, "$start--$end")
+        val dashReplacement = "$start--$end"
+        document.replaceString(replacementRange.start, replacementRange.endInclusive, dashReplacement)
+
+        return dashReplacement.length - (replacementRange.endInclusive - replacementRange.start)
     }
 }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexEnDashInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexEnDashInspection.kt
@@ -25,7 +25,7 @@ open class LatexEnDashInspection : TexifyRegexInspection(
         groupFetcher = { listOf(it.group(2), it.group(3)) }
 ) {
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
+    override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
         val file = descriptor.psiElement as PsiFile
         val document = file.document() ?: return 0
         val start = groups[0]

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
@@ -54,13 +54,6 @@ open class LatexExtremeInequalityInspection : TexifyRegexInspection(
         }
     }
 
-    override fun runForWholeFile(): Boolean {
-        // The quickfix of this inspection replaces text (like <<) by
-        // content with a different length (like \ll), so we have to make
-        // sure it is run for the whole file at once.
-        return true
-    }
-
     override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<String>) {
         super.applyFixes(project, descriptor, replacementRanges, replacements, groups)
 

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
@@ -54,8 +54,8 @@ open class LatexExtremeInequalityInspection : TexifyRegexInspection(
         }
     }
 
-    override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>) {
-        super.applyFixes(project, descriptor, replacementRanges, replacements, groups)
+    override fun applyFixes(descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>) {
+        super.applyFixes(descriptor, replacementRanges, replacements, groups)
 
         // We overrided applyFixes instead of applyFix because all fixes need to be applied together, and only after that we insert any required package.
         val file = descriptor.psiElement.containingFile ?: return

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
@@ -54,10 +54,10 @@ open class LatexExtremeInequalityInspection : TexifyRegexInspection(
         }
     }
 
-    override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<String>) {
+    override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<List<String>>) {
         super.applyFixes(project, descriptor, replacementRanges, replacements, groups)
 
-        // We override applyFixes instead of applyFix because all fixes need to be applied together, and only after that we insert any required package.
+        // We overrided applyFixes instead of applyFix because all fixes need to be applied together, and only after that we insert any required package.
         val file = descriptor.psiElement.containingFile ?: return
         file.insertUsepackage(AMSSYMB)
     }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
@@ -54,6 +54,10 @@ open class LatexExtremeInequalityInspection : TexifyRegexInspection(
         }
     }
 
+    override fun runForWholeFile(): Boolean {
+        return true
+    }
+
     override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>) {
         super.applyFix(project, descriptor, replacementRange, replacement, groups)
 

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexExtremeInequalityInspection.kt
@@ -55,12 +55,16 @@ open class LatexExtremeInequalityInspection : TexifyRegexInspection(
     }
 
     override fun runForWholeFile(): Boolean {
+        // The quickfix of this inspection replaces text (like <<) by
+        // content with a different length (like \ll), so we have to make
+        // sure it is run for the whole file at once.
         return true
     }
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>) {
-        super.applyFix(project, descriptor, replacementRange, replacement, groups)
+    override fun applyFixes(project: Project, descriptor: ProblemDescriptor, replacementRanges: List<IntRange>, replacements: List<String>, groups: List<String>) {
+        super.applyFixes(project, descriptor, replacementRanges, replacements, groups)
 
+        // We override applyFixes instead of applyFix because all fixes need to be applied together, and only after that we insert any required package.
         val file = descriptor.psiElement.containingFile ?: return
         file.insertUsepackage(AMSSYMB)
     }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexPrimitiveEquationInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexPrimitiveEquationInspection.kt
@@ -31,11 +31,14 @@ open class LatexPrimitiveEquationInspection : TexifyRegexInspection(
         fun replaceRange(it: Matcher) = (it.groupRange(1).start..it.groupRange(2).endInclusive)
     }
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>) {
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
         val file = descriptor.psiElement as PsiFile
-        val document = file.document() ?: return
+        val document = file.document() ?: return 0
 
         document.replaceString(replacementRange.start, replacementRange.start + 2, "\\[")
         document.replaceString(replacementRange.endInclusive - 2, replacementRange.endInclusive, "\\]")
+
+        // $$ were replaced by \[ or \] so the length did not change
+        return 0
     }
 }

--- a/src/nl/rubensten/texifyidea/inspections/latex/LatexPrimitiveEquationInspection.kt
+++ b/src/nl/rubensten/texifyidea/inspections/latex/LatexPrimitiveEquationInspection.kt
@@ -31,7 +31,7 @@ open class LatexPrimitiveEquationInspection : TexifyRegexInspection(
         fun replaceRange(it: Matcher) = (it.groupRange(1).start..it.groupRange(2).endInclusive)
     }
 
-    override fun applyFix(project: Project, descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
+    override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
         val file = descriptor.psiElement as PsiFile
         val document = file.document() ?: return 0
 

--- a/src/nl/rubensten/texifyidea/run/evince/EvinceConversation.kt
+++ b/src/nl/rubensten/texifyidea/run/evince/EvinceConversation.kt
@@ -97,7 +97,8 @@ object EvinceConversation {
             // not succeed with a NoReply exception, so we will execute a command via the shell
             val command = "gdbus call --session --dest $processOwner --object-path /org/gnome/evince/Window/0 --method org.gnome.evince.Window.SyncView $sourceFilePath '($line, 1)' 0"
             Runtime.getRuntime().exec(arrayOf("bash", "-c", command))
-        } else {
+        }
+        else {
             throw TeXception("Could not execute forward search with Evince because something went wrong when finding the pdf file.")
         }
     }

--- a/src/nl/rubensten/texifyidea/util/General.kt
+++ b/src/nl/rubensten/texifyidea/util/General.kt
@@ -42,6 +42,12 @@ fun runWriteAction(writeAction: () -> Unit) {
 fun IntRange.toTextRange() = TextRange(this.start, this.endInclusive + 1)
 
 /**
+ * Get the length of an [IntRange].
+ */
+val IntRange.length: Int
+    get() = endInclusive - start
+
+/**
  * Converts a [TextRange] to [IntRange].
  */
 fun TextRange.toIntRange() = startOffset..endOffset

--- a/test/nl/rubensten/texifyidea/inspections/TexifyRegexInspectionTest.kt
+++ b/test/nl/rubensten/texifyidea/inspections/TexifyRegexInspectionTest.kt
@@ -1,68 +1,38 @@
 package nl.rubensten.texifyidea.inspections
 
-import com.intellij.codeInspection.ProblemDescriptor
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ex.ProblemDescriptorImpl
-import com.intellij.mock.MockProject
-import com.intellij.mock.MockProjectEx
-import com.intellij.mock.MockPsiElement
-import com.intellij.mock.MockPsiFile
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiManager
-import com.intellij.testFramework.LightProjectDescriptor
-import com.intellij.testFramework.MockProblemDescriptor
-import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor
-import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
-import nl.rubensten.texifyidea.psi.BibtexQuotedString
-import nl.rubensten.texifyidea.psi.LatexMathContent
 import nl.rubensten.texifyidea.util.length
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.util.regex.Pattern
 
-class TexifyRegexInspectionTest : LightCodeInsightFixtureTestCase() {
+class TexifyRegexInspectionTest {
 
-    class DummyRegexInspection : TexifyRegexInspection(
+    class MockRegexInspection : TexifyRegexInspection(
             inspectionDisplayName = "",
             myInspectionId = "",
             errorMessage = { "" },
             pattern = Pattern.compile("aaa.aaa"),
-            mathMode = true,
             replacement = { _, _ -> "The replacement" },
-            replacementRange = { IntRange(24, 42) },
-            quickFixName = { "Insert amssymb symbol." }) {
+            replacementRange = { IntRange(24, 42) }) {
 
         // Provide dummy document contents
         val dummyDocument = "The words aaabaaa and aaacaaa should both be replaced in the correct location."
 
         // Remove the first part of the applyfix functionality to avoid trying to replace things in a non-existing file
-        override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
+        fun mockApplyFix(replacementRange: IntRange, replacement: String): Int {
             dummyDocument.replaceRange(replacementRange.start, replacementRange.endInclusive, replacement)
-
             return replacement.length - replacementRange.length
         }
-    }
-//
-//    class MyProjectDescriptor : LightProjectDescriptor() {
-//
-//    }
-
-    override fun getProjectDescriptor(): LightProjectDescriptor {
-        return DefaultLightProjectDescriptor()
     }
 
     @Test
     fun testApplyFixesTwoReplacements() {
-        val dummy = DummyRegexInspection()
+        val dummy = MockRegexInspection()
         val replacementRanges = arrayListOf(IntRange(10, 17), IntRange(22, 28))
         val replacements = arrayListOf("Replacement1", "Replacement2")
-        val groups = arrayListOf<List<String>>(arrayListOf())
+        val groupsList = arrayListOf<List<String>>(arrayListOf("aaabaaa"), arrayListOf("aaacaaa"))
 
-//        val dummyProject = MockProject()
-//        val dummyPsiElement = MockPsiElement("eh?", dummyProject)
-        val dummyPsiElement = MockPsiFile(PsiManager.getInstance(MockProjectEx {}))
-        val dummyProblemDescriptor = MockProblemDescriptor(dummyPsiElement, "", ProblemHighlightType.ERROR)
-        dummy.applyFixes(dummyProblemDescriptor, replacementRanges, replacements, groups)
+        dummy.applyFixes({ replacementRange, replacement, _ -> dummy.mockApplyFix(replacementRange, replacement) }, replacementRanges, replacements, groupsList)
 
         assertEquals("The words Replacement1 and Replacement2 should both be replaced in the correct location.", dummy.dummyDocument)
     }

--- a/test/nl/rubensten/texifyidea/inspections/TexifyRegexInspectionTest.kt
+++ b/test/nl/rubensten/texifyidea/inspections/TexifyRegexInspectionTest.kt
@@ -11,16 +11,44 @@ class TexifyRegexInspectionTest {
             inspectionDisplayName = "",
             myInspectionId = "",
             errorMessage = { "" },
-            pattern = Pattern.compile("aaa.aaa"),
+            pattern = Pattern.compile("a.a"),
             replacement = { _, _ -> "The replacement" },
             replacementRange = { IntRange(24, 42) }) {
 
         // Provide dummy document contents
-        val dummyDocument = "The words aaabaaa and aaacaaa should both be replaced in the correct location."
+        var dummyDocument = ""
 
-        // Remove the first part of the applyfix functionality to avoid trying to replace things in a non-existing file
+        /**
+         * Inspect the file without the parts of [inspectFile] that require a real PsiFile.
+         * For the tests, replacement ranges and replacements could also be done manually but this is slightly easier,
+         * because the tests in this file do not aim to test [inspectFile] anyway.
+         */
+        fun mockInspectFile() : RegexFixes {
+            val replacementRanges = arrayListOf<IntRange>()
+            val replacements = arrayListOf<String>()
+            val groups = arrayListOf<List<String>>()
+
+            val matcher = pattern.matcher(dummyDocument)
+            while (matcher.find()) {
+                val range = replacementRange(matcher)
+                val replacementContent = "Replacement"
+
+                replacementRanges.add(range)
+                replacements.add(replacementContent)
+                groups.add(groupFetcher(matcher))
+            }
+
+            return RegexFixes(
+                    quickFixName(matcher),
+                    replacements,
+                    replacementRanges,
+                    groups,
+                    this::applyFixes)
+        }
+
+        // Remove the ProblemDescriptor part of the applyfix functionality to avoid trying to replace things in a non-existing file
         fun mockApplyFix(replacementRange: IntRange, replacement: String): Int {
-            dummyDocument.replaceRange(replacementRange.start, replacementRange.endInclusive, replacement)
+            dummyDocument = dummyDocument.replaceRange(replacementRange.start, replacementRange.endInclusive, replacement)
             return replacement.length - replacementRange.length
         }
     }
@@ -28,11 +56,13 @@ class TexifyRegexInspectionTest {
     @Test
     fun testApplyFixesTwoReplacements() {
         val dummy = MockRegexInspection()
-        val replacementRanges = arrayListOf(IntRange(10, 17), IntRange(22, 28))
-        val replacements = arrayListOf("Replacement1", "Replacement2")
-        val groupsList = arrayListOf<List<String>>(arrayListOf("aaabaaa"), arrayListOf("aaacaaa"))
+        dummy.dummyDocument = "The words aba and aca should both be replaced in the correct location."
 
-        dummy.applyFixes({ replacementRange, replacement, _ -> dummy.mockApplyFix(replacementRange, replacement) }, replacementRanges, replacements, groupsList)
+        val fixes = dummy.mockInspectFile()
+        val fixFunction = { replacementRange: IntRange, replacement: String, _: List<String> ->
+            dummy.mockApplyFix(replacementRange, replacement) }
+
+        dummy.applyFixes(fixFunction, fixes.replacementRanges, fixes.replacements, fixes.groups)
 
         assertEquals("The words Replacement1 and Replacement2 should both be replaced in the correct location.", dummy.dummyDocument)
     }

--- a/test/nl/rubensten/texifyidea/inspections/TexifyRegexInspectionTest.kt
+++ b/test/nl/rubensten/texifyidea/inspections/TexifyRegexInspectionTest.kt
@@ -1,0 +1,69 @@
+package nl.rubensten.texifyidea.inspections
+
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ex.ProblemDescriptorImpl
+import com.intellij.mock.MockProject
+import com.intellij.mock.MockProjectEx
+import com.intellij.mock.MockPsiElement
+import com.intellij.mock.MockPsiFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.testFramework.LightProjectDescriptor
+import com.intellij.testFramework.MockProblemDescriptor
+import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import nl.rubensten.texifyidea.psi.BibtexQuotedString
+import nl.rubensten.texifyidea.psi.LatexMathContent
+import nl.rubensten.texifyidea.util.length
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.regex.Pattern
+
+class TexifyRegexInspectionTest : LightCodeInsightFixtureTestCase() {
+
+    class DummyRegexInspection : TexifyRegexInspection(
+            inspectionDisplayName = "",
+            myInspectionId = "",
+            errorMessage = { "" },
+            pattern = Pattern.compile("aaa.aaa"),
+            mathMode = true,
+            replacement = { _, _ -> "The replacement" },
+            replacementRange = { IntRange(24, 42) },
+            quickFixName = { "Insert amssymb symbol." }) {
+
+        // Provide dummy document contents
+        val dummyDocument = "The words aaabaaa and aaacaaa should both be replaced in the correct location."
+
+        // Remove the first part of the applyfix functionality to avoid trying to replace things in a non-existing file
+        override fun applyFix(descriptor: ProblemDescriptor, replacementRange: IntRange, replacement: String, groups: List<String>): Int {
+            dummyDocument.replaceRange(replacementRange.start, replacementRange.endInclusive, replacement)
+
+            return replacement.length - replacementRange.length
+        }
+    }
+//
+//    class MyProjectDescriptor : LightProjectDescriptor() {
+//
+//    }
+
+    override fun getProjectDescriptor(): LightProjectDescriptor {
+        return DefaultLightProjectDescriptor()
+    }
+
+    @Test
+    fun testApplyFixesTwoReplacements() {
+        val dummy = DummyRegexInspection()
+        val replacementRanges = arrayListOf(IntRange(10, 17), IntRange(22, 28))
+        val replacements = arrayListOf("Replacement1", "Replacement2")
+        val groups = arrayListOf<List<String>>(arrayListOf())
+
+//        val dummyProject = MockProject()
+//        val dummyPsiElement = MockPsiElement("eh?", dummyProject)
+        val dummyPsiElement = MockPsiFile(PsiManager.getInstance(MockProjectEx {}))
+        val dummyProblemDescriptor = MockProblemDescriptor(dummyPsiElement, "", ProblemHighlightType.ERROR)
+        dummy.applyFixes(dummyProblemDescriptor, replacementRanges, replacements, groups)
+
+        assertEquals("The words Replacement1 and Replacement2 should both be replaced in the correct location.", dummy.dummyDocument)
+    }
+}


### PR DESCRIPTION
Fixes #826 

The problem was that RegexFixes have a fixed location. That means, when there are multiple problem descriptors in a file, and the user selects Fix All, that IntelliJ will apply the fixes one by one for all problem descriptors. That means that when a fix or a certain problem replaces text with other text _of a different length_, all the locations of all subsequent problem descriptors will be wrong.

One solution would be to rescan the complete file after each fix, but for performance reasons (and because I didn't know how to rescan a file anyway) I chose to calculate a cumulative displacement, which is then taken into account when applying the next fixes in the file.

The implementation is a bit more roundabout, because the loop which loops over all problem descriptors in a file is internal in the intellij sdk, so I chose to create only one problem descriptor for the whole file which contains all the fixes, so we  can loop over the fixes ourselves and control the displacement variable. Of course this is done _only_ when the user clicks Fix All - then the file is inspected _not_ on the fly, so the one problem descriptor is not shown.

#### Additions

* Added a check to `TexifyRegexInspection.inspectFile` to check if a Fix All is run, and create only one problem descriptor if so
* Override the `runForWholeFile()` of `LocalInspectionTool`, as true and take it into account in the above check, so inspections can override this back to false if they want to disable the 'one problem descriptor' behaviour.
* Create an `applyFixes` method which loops over all the fixes of a problem descriptor, and calls `applyFix` for each of them while taking care of the displacements.

#### Changes

* `applyFix` has to return the total displacement of the fix, otherwise `applyFixes` cannot know what has happened.
* `RegexFix` was changed to be able to handle more fixes
* Inspections with a custom `applyFix` were changed to work with the new behaviour.

The changed inspections were tested that the Fix All behaviour works now.

Sorry for the long story :) 