### PR TITLE
Method separator colours for sections are now based on the structure level

### DIFF
--- a/src/nl/rubensten/texifyidea/insight/LatexLineMarkerProvider.kt
+++ b/src/nl/rubensten/texifyidea/insight/LatexLineMarkerProvider.kt
@@ -12,10 +12,12 @@ import nl.rubensten.texifyidea.util.Magic
 /**
  * Provides line markers for the LaTeX language.
  *
- * @author Sten Wessel
+ * @author Ruben Schellekens, Sten Wessel
  */
-class LatexLineMarkerProvider(private val daemonSettings: DaemonCodeAnalyzerSettings,
-                              private val colorsManager: EditorColorsManager) : LineMarkerProvider {
+class LatexLineMarkerProvider(
+        private val daemonSettings: DaemonCodeAnalyzerSettings,
+        private val colorsManager: EditorColorsManager
+) : LineMarkerProvider {
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         // Method separators before sectioning commands
@@ -23,11 +25,15 @@ class LatexLineMarkerProvider(private val daemonSettings: DaemonCodeAnalyzerSett
 
         val commandToken = element.commandToken.text
         return if (commandToken in Magic.Command.sectionMarkers) {
-            LineMarkersPass.createMethodSeparatorLineMarker(element.commandToken, colorsManager)
+            LineMarkersPass.createMethodSeparatorLineMarker(element.commandToken, colorsManager).apply {
+                separatorColor = Magic.Command.sectionSeparatorColors[commandToken]
+            }
         }
         else null
     }
 
-    override fun collectSlowLineMarkers(elements: MutableList<PsiElement>,
-                                        result: MutableCollection<LineMarkerInfo<PsiElement>>) = Unit
+    override fun collectSlowLineMarkers(
+            elements: MutableList<PsiElement>,
+            result: MutableCollection<LineMarkerInfo<PsiElement>>
+    ) = Unit
 }

--- a/src/nl/rubensten/texifyidea/util/Magic.kt
+++ b/src/nl/rubensten/texifyidea/util/Magic.kt
@@ -6,6 +6,7 @@ import nl.rubensten.texifyidea.TexifyIcons
 import nl.rubensten.texifyidea.file.*
 import nl.rubensten.texifyidea.inspections.latex.LatexLineBreakInspection
 import nl.rubensten.texifyidea.lang.Package
+import java.awt.Color
 import java.util.regex.Pattern
 
 typealias LatexPackage = Package
@@ -268,6 +269,19 @@ object Magic {
                 "\\part", "\\chapter",
                 "\\section", "\\subsection", "\\subsubsection",
                 "\\paragraph", "\\subparagraph"
+        )
+
+        /**
+         * The colours that each section separator has.
+         */
+        @JvmField val sectionSeparatorColors = mapOf(
+                "\\part" to Color(152, 152, 152),
+                "\\chapter" to Color(172, 172, 172),
+                "\\section" to Color(182, 182, 182),
+                "\\subsection" to Color(202, 202, 202),
+                "\\subsubsection" to Color(212, 212, 212),
+                "\\paragraph" to Color(222, 222, 222),
+                "\\subparagraph" to Color(232, 232, 232)
         )
     }
 


### PR DESCRIPTION
Resolves #901.

...\part lines are darker than \section lines are darker than \paragraph
lines etc.

![image](https://user-images.githubusercontent.com/17410729/59100369-1f653600-8926-11e9-9ab0-91eca9ea0cee.png)
