### PR TITLE
Brace matcher also matches "\begin" / "\end" pairs

### DIFF
--- a/src/nl/rubensten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
+++ b/src/nl/rubensten/texifyidea/highlighting/LatexPairedBraceMatcher.kt
@@ -16,6 +16,7 @@ class LatexPairedBraceMatcher : PairedBraceMatcher {
         private val bracePairs = arrayOf(
                 BracePair(LatexTypes.DISPLAY_MATH_START, LatexTypes.DISPLAY_MATH_END, true),
                 BracePair(LatexTypes.INLINE_MATH_START, LatexTypes.INLINE_MATH_END, true),
+                BracePair(LatexTypes.BEGIN_TOKEN, LatexTypes.END_TOKEN, false),
                 BracePair(LatexTypes.OPEN_PAREN, LatexTypes.CLOSE_PAREN, false),
                 BracePair(LatexTypes.OPEN_BRACE, LatexTypes.CLOSE_BRACE, false),
                 BracePair(LatexTypes.OPEN_BRACKET, LatexTypes.CLOSE_BRACKET, false),


### PR DESCRIPTION
#### Additions

Added `\begin` and `\end` paired brace matching.

#### Changes

N/A

#### Backwards incompatible changes

N/A