### PR TITLE
Append compiler arguments to bash command argument when using WSL

### DIFF
--- a/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
+++ b/src/nl/hannahsten/texifyidea/run/compiler/LatexCompiler.kt
@@ -319,12 +319,12 @@ enum class LatexCompiler(private val displayName: String, val executableName: St
         )
 
         if (runConfig.getLatexDistributionType() == LatexDistributionType.WSL_TEXLIVE) {
-            var wslCommand = GeneralCommandLine(command).commandLineString;
+            var wslCommand = GeneralCommandLine(command).commandLineString
 
             // Custom compiler arguments specified by the user
             runConfig.compilerArguments?.let { arguments ->
                 ParametersListUtil.parse(arguments)
-                        .forEach { wslCommand += " ${it}" }
+                        .forEach { wslCommand += " $it" }
             }
 
             wslCommand += " ${mainFile.path.toPath(runConfig)}"


### PR DESCRIPTION
Fix #2541

#### Summary of additions and changes

Add compiler arguments to the bash -ic command argument (similar to what was done for the main file).

#### How to test this pull request

See [#2541](https://github.com/Hannah-Sten/TeXiFy-IDEA/issues/2541) for instructions.