### PR TITLE
Unlock document before executing RightInsertHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix exception #4160 when using a tool window in non-IntelliJ IDEs
 * Fix exceptions when using a makeindex run configuration
 * Fix an issue with relative paths in graphic insertion wizard
+* Fix exception #4144
 
 ## [0.11.0] - 2025-08-04
 

--- a/src/nl/hannahsten/texifyidea/completion/handlers/RightInsertHandler.kt
+++ b/src/nl/hannahsten/texifyidea/completion/handlers/RightInsertHandler.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.psi.PsiDocumentManager
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.lang.commands.LatexCommand
 import nl.hannahsten.texifyidea.lang.commands.LatexDelimiterCommand
@@ -21,6 +22,7 @@ open class RightInsertHandler : InsertHandler<LookupElement> {
 
         if (command is LatexDelimiterCommand && command.isLeft) {
             val hasMatchingBrace = BraceMatchingUtil.matchBrace(context.editor.document.text, LatexFileType, editor.highlighter.createIterator(context.editor.caretModel.offset - 1), true)
+            PsiDocumentManager.getInstance(editor.project ?: return).doPostponedOperationsAndUnblockDocument(editor.document)
             if (hasMatchingBrace) {
                 editor.document.insertString(editor.caretModel.offset, " ")
             } else {


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4144