### PR TITLE
Fix 'file not found' error for input commands without extension specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix 'file not found' error for input commands without extension specified
 * Fix symbol tool window insertion
 * Do not override build project action if there are no run configurations
 

--- a/src/nl/hannahsten/texifyidea/index/LatexProjectStructure.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexProjectStructure.kt
@@ -42,29 +42,16 @@ import nl.hannahsten.texifyidea.lang.predefined.CommandNames.EXTERNAL_DOCUMENT
 import nl.hannahsten.texifyidea.psi.LatexCommands
 import nl.hannahsten.texifyidea.psi.nameWithSlash
 import nl.hannahsten.texifyidea.settings.TexifySettings
-import nl.hannahsten.texifyidea.util.AbstractBlockingCacheService
-import nl.hannahsten.texifyidea.util.CacheValueTimed
-import nl.hannahsten.texifyidea.util.GenericCacheService
-import nl.hannahsten.texifyidea.util.Log
-import nl.hannahsten.texifyidea.util.TexifyProjectCacheService
-import nl.hannahsten.texifyidea.util.contentSearchScope
-import nl.hannahsten.texifyidea.util.expandCommandsOnce
+import nl.hannahsten.texifyidea.util.*
 import nl.hannahsten.texifyidea.util.files.LatexPackageLocation
 import nl.hannahsten.texifyidea.util.files.allChildDirectories
-import nl.hannahsten.texifyidea.util.getBibtexRunConfigurations
-import nl.hannahsten.texifyidea.util.getLatexRunConfigurations
-import nl.hannahsten.texifyidea.util.getTexinputsPaths
 import nl.hannahsten.texifyidea.util.magic.CommandMagic
 import nl.hannahsten.texifyidea.util.magic.PatternMagic
-import nl.hannahsten.texifyidea.util.projectSearchScope
-import nl.hannahsten.texifyidea.util.unionBy
 import java.io.File
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
-import java.util.SequencedSet
-import kotlin.collections.contains
+import java.util.*
 import kotlin.io.path.Path
-import kotlin.io.path.extension
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.name
 import kotlin.io.path.pathString
@@ -590,12 +577,14 @@ object LatexProjectStructure {
                 paramTexts.asSequence().map { text ->
                     val text = pathTextExtraProcessing(text, command, file)
                     pathOrNull(text)?.let { path ->
-                        if (path.extension.isNotEmpty() || noExtensionProvided) {
+                        // If a file a.b.tex exists, \input{a.b} prefers a.b.tex over a.b
+                        if (noExtensionProvided) {
                             sequenceOf(path)
                         }
                         else {
                             path.name.let { fileName ->
-                                extensionSeq.map { ext -> path.resolveSibling("$fileName.$ext") }
+                                // For some commands, like \input, the extension is optional, for now we always try it
+                                extensionSeq.map { ext -> path.resolveSibling("$fileName.$ext") } + listOf(path.resolveSibling(fileName))
                             }
                         }
                     } ?: emptySequence()

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexFileNotFoundInspectionTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.gutter.LatexNavigationGutter
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.updateFilesets
 import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 import java.io.File
 import java.nio.file.Path
@@ -196,6 +197,30 @@ class LatexFileNotFoundInspectionTest : TexifyInspectionTestBase(LatexFileNotFou
         // Contrary to \includegraphics, \input will accept a file with any extension if specified
         myFixture.addFileToProject("included.txt", "\\LaTeX content")
         myFixture.configureByText(LatexFileType, "\\input{included.txt}")
+        myFixture.checkHighlighting()
+    }
+
+    fun testPlainInclude() {
+        // \input prefers .tex files if they exist
+        myFixture.addFileToProject("no-ext", "text content")
+        myFixture.configureByText(LatexFileType, "\\input{no-ext}")
+        myFixture.updateFilesets()
+        myFixture.checkHighlighting()
+    }
+
+    fun testMultipleDots() {
+        // \input prefers .tex files if they exist
+        myFixture.addFileToProject("included.v1.0", "text content")
+        myFixture.configureByText(LatexFileType, "\\input{included.v1.0}")
+        myFixture.updateFilesets()
+        myFixture.checkHighlighting()
+    }
+
+    fun testMultipleDotsTex() {
+        // \input prefers .tex files if they exist
+        myFixture.addFileToProject("included.v1.0.tex", "\\LaTeX content")
+        myFixture.configureByText(LatexFileType, "\\input{included.v1.0}")
+        myFixture.updateFilesets()
         myFixture.checkHighlighting()
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4265