### PR TITLE
Fix duplicate messages in log message tab after filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Fixed
+* Fix duplicate messages in log message tab after filtering
 
 ## [0.11.7] - 2026-01-09
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.11.7
+pluginVersion = 0.11.8-alpha.1
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexLogMessage.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/LatexLogMessage.kt
@@ -10,7 +10,9 @@ data class LatexLogMessage(val message: String, val fileName: String? = null, va
     fun toTreeViewString(): String {
         val typeString = type.toString().lowercase(Locale.getDefault()).capitalizeFirst()
         val lineString = if (line >= 0) "line ($line)" else ""
-        return "$typeString:$lineString $message"
+        // Should match ErrorTreeElement.fullString()
+        val exportTextPrefix = if (file != null) "$typeString:$lineString" else ""
+        return "$exportTextPrefix $message"
     }
 }
 

--- a/src/nl/hannahsten/texifyidea/run/latex/logtab/ui/LatexCompileMessageTreeView.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/logtab/ui/LatexCompileMessageTreeView.kt
@@ -3,6 +3,7 @@ package nl.hannahsten.texifyidea.run.latex.logtab.ui
 import com.intellij.icons.AllIcons
 import com.intellij.ide.IdeBundle
 import com.intellij.ide.errorTreeView.ErrorTreeElement
+import com.intellij.ide.errorTreeView.GroupingElement
 import com.intellij.ide.errorTreeView.NewErrorTreeViewPanel
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.project.DumbAware
@@ -41,14 +42,18 @@ class LatexCompileMessageTreeView(
     /**
      * Get all elements that are currently in the tree.
      *
-     * Elements are located as direct children of a file, which are direct children of the root.
+     * Elements are located as direct children of the root (in case no file is known), or
+     * as children of a file, which are direct children of the root.
      * Therefore, we only have to look one level deep to get all the messages.
      */
     private fun getAllElements(): List<ErrorTreeElement> {
         this@LatexCompileMessageTreeView.errorViewStructure.let { tree ->
-            return tree.getChildElements(tree.rootElement).flatMap {
-                tree.getChildElements(it).toList()
-            }
+            val childElements = tree.getChildElements(tree.rootElement).toList()
+            return (
+                childElements + childElements.flatMap {
+                    tree.getChildElements(it).toList()
+                }
+                ).filter { it !is GroupingElement }
         }
     }
 


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4377
