### PR TITLE
Implement local file check in LatexProjectStructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add run configuration option to set working directory
 
 ### Fixed
+* Package imports now resolve to only the local package if it exists, by @jandermoreira 
 * Fix bug in retrieving texmfhome directory on Linux
 * Fix duplicate messages in log message tab after filtering
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 0.11.8-alpha.2
+pluginVersion = 0.11.8-alpha.3
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/index/LatexProjectStructure.kt
+++ b/src/nl/hannahsten/texifyidea/index/LatexProjectStructure.kt
@@ -460,18 +460,9 @@ object LatexProjectStructure {
         ) {
             for ((paths, refInfo) in elements.zip(refInfoList)) {
                 for (path in paths) {
-                    // check local package first
-                    val localFile =
-                        if (path.isAbsolute) {
-                            path.findVirtualFile()
-                        }
-                        else {
-                            currentRootDir?.findFileByRelativePath(path.invariantSeparatorsPathString)
-                                ?: rootDirs.firstNotNullOfOrNull { dir ->
-                                    dir.findFileByRelativePath(path.invariantSeparatorsPathString)
-                                }
-                        }
-        
+                    // check local package first, since LaTeX will resolve to the local package if it exists
+                    val localFile = findLocalFile(path, rootDirs)
+
                     if (localFile != null) {
                         processNext(localFile)
                         refInfo.add(localFile)
@@ -497,13 +488,18 @@ object LatexProjectStructure {
             elements: List<Sequence<Path>>, refInfoList: List<MutableSet<VirtualFile>>, rootDirs: Collection<VirtualFile>,
         ) {
             processElementsWithPaths(elements, refInfoList) { path ->
-                if (path.isAbsolute) path.findVirtualFile()
-                else {
-                    val pathString = path.invariantSeparatorsPathString
-                    currentRootDir?.findFileByRelativePath(pathString) ?: rootDirs.firstNotNullOfOrNull { sourcePath ->
-                        sourcePath.findFileByRelativePath(pathString)
-                    }
-                }
+                findLocalFile(path, rootDirs)
+            }
+        }
+
+        private fun findLocalFile(
+            path: Path,
+            rootDirs: Collection<VirtualFile>
+        ): VirtualFile? = if (path.isAbsolute) path.findVirtualFile()
+        else {
+            val pathString = path.invariantSeparatorsPathString
+            currentRootDir?.findFileByRelativePath(pathString) ?: rootDirs.firstNotNullOfOrNull { sourcePath ->
+                sourcePath.findFileByRelativePath(pathString)
             }
         }
 


### PR DESCRIPTION
(Original: #4393)

> Added logic to check for local files before library packages in LatexProjectStructure.
> 
> Fix #4234
> 
> #### Summary of additions and changes
> 
> * Local packages are loaded if present; otherwise library packages are checked
> 