### PR TITLE
Add forward search intention action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add missing context for alignat and split environments
 * Add support for the currfile package
 * Add support for loading packages using \UseTblrLibrary from tabularray
+* Add intention to forward search in PDF 
 * Updated dependencies
 
 ### Fixed

--- a/Writerside/topics/PDF-viewers.md
+++ b/Writerside/topics/PDF-viewers.md
@@ -7,7 +7,7 @@ _Since b0.7.4_
 TeXiFy supports using the [PDF Viewer](https://plugins.jetbrains.com/plugin/14494-pdf-viewer) plugin to view PDFs inside the IDE.
 This includes forward and inverse search functionality.
 
-To forward search, use <ui-path>Tools | LaTeX | Forward search</ui-path> or the shortcut listed there.
+To forward search, use <ui-path>Tools | LaTeX | Forward search</ui-path>, the shortcut listed there, or <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 To inverse search, use <shortcut>Ctrl + click</shortcut>.
 
 To use the PDF Viewer plugin, install it via the plugin settings in your IDE.
@@ -36,13 +36,13 @@ If it does not, you can specify the path to the executable in the [TeXiFy settin
 
 ### Shortcuts {id="sumatra-shortcuts"}
 
-The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>.
+The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>, or use <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 The default shortcut for backward search in SumatraPDF is a double left mouse click.
 
 ### Explanation
 
 #### Forward search {id="sumatra-forward-search"}
-When your cursor is in IntelliJ and you have just compiled a document, you can look up which line in the pdf corresponds to the line your cursor is at by going in IntelliJ to the menu <ui-path>Tools | LaTeX | SumatraPDF | Forward Search</ui-path>, or using the shortcut <shortcut>Ctrl + Alt + Shift + .</shortcut> which is listed there.
+When your cursor is in IntelliJ and you have just compiled a document, you can look up which line in the pdf corresponds to the line your cursor is at by going in IntelliJ to the menu <ui-path>Tools | LaTeX | SumatraPDF | Forward Search</ui-path>, using the shortcut <shortcut>Ctrl + Alt + Shift + .</shortcut> which is listed there, or using <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 This shortcut can also be used to bring the SumatraPDF window in view when you recompiled a document but you do not see it.
 
 #### Backward or inverse search {id="sumatra-inverse-search"}
@@ -79,13 +79,13 @@ On non-Windows systems, TeXiFy supports Evince as a pdf viewer with forward and 
 
 ### Shortcuts {id="evince-shortcuts"}
 
-The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>.
+The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>, or use <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 The default shortcut for backward search in Evince is <shortcut>Ctrl + Left mouse click</shortcut>.
 
 Note that spaces in your path (including filename) are not allowed.
 
 ### Forward search {id="evince-forward-search"}
-When your cursor is in IntelliJ and you have just compiled a document, you can look up which line in the pdf corresponds to the line your cursor is at by going in IntelliJ to the menu <ui-path>Tools | LaTeX | Evince | Forward Search</ui-path>, or using the shortcut <shortcut>Ctrl + Alt + Shift + .</shortcut> which is listed there.
+When your cursor is in IntelliJ and you have just compiled a document, you can look up which line in the pdf corresponds to the line your cursor is at by going in IntelliJ to the menu <ui-path>Tools | LaTeX | Evince | Forward Search</ui-path>, using the shortcut <shortcut>Ctrl + Alt + Shift + .</shortcut> which is listed there, or using <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 This shortcut can also be used to bring the Evince window in view when you do not see it.
 
 ### Backward or inverse search {id="evince-inverse-search"}
@@ -101,7 +101,7 @@ _Since b0.6.7_
 On Linux systems, TeXiFy supports Okular as a pdf viewer with forward and inverse search.
 
 ### Shortcuts {id="okular-shortcuts"}
-The default shortcut for forward search in IntelliJ is is <shortcut>Ctrl + Alt + Shift + .</shortcut>.
+The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>, or use <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 The default shortcut for inverse search in Okular is <shortcut>Shift + Left mouse click</shortcut>.
 
 ### Configuring inverse (or backwards) search {id="okular-inverse-search"}
@@ -128,13 +128,13 @@ On non-Windows systems, TeXiFy supports [Zathura](https://pwmt.org/projects/zath
 
 ### Shortcuts {id="zathura-shortcuts"}
 
-The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>.
+The default shortcut for forward search in IntelliJ is <shortcut>Ctrl + Alt + Shift + .</shortcut>, or use <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 The default shortcut for backward search in Zathura is <shortcut>Ctrl + Left mouse click</shortcut>.
 
 Note that spaces in your path (including filename) are not allowed.
 
 ### Forward search {id="zathura-forward-search"}
-When your cursor is in IntelliJ and you have just compiled a document, you can look up which line in the pdf corresponds to the line your cursor is at by going in IntelliJ to the menu <ui-path>Tools | LaTeX | Zathura | Forward Search</ui-path>, or using the shortcut <shortcut>Ctrl + Alt + Shift + .</shortcut> which is listed there.
+When your cursor is in IntelliJ and you have just compiled a document, you can look up which line in the pdf corresponds to the line your cursor is at by going in IntelliJ to the menu <ui-path>Tools | LaTeX | Zathura | Forward Search</ui-path>, using the shortcut <shortcut>Ctrl + Alt + Shift + .</shortcut> which is listed there, or using <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 This shortcut can also be used to bring the Zathura window in view when you do not see it.
 
 ### Backward or inverse search {id="zathura-inverse-search"}
@@ -148,7 +148,7 @@ _Since b0.6.8_
 On MacOS, TeXiFy supports Skim as a pdf viewer with forward and inverse search.
 
 ### Shortcuts {id="skim-shortcuts"}
-The default shortcut for forward search in IntelliJ is is <shortcut>⌥ + ⇧ + ⌘ + .</shortcut>.
+The default shortcut for forward search in IntelliJ is <shortcut>⌥ + ⇧ + ⌘ + .</shortcut>, or use <shortcut>Alt + Enter</shortcut> -> <control>Forward search in PDF</control>.
 The default shortcut for inverse search in Skim is <shortcut>⌘ + ⇧ + Click</shortcut>.
 
 ### Configuring inverse (or backwards) search {id="skim-inverse-search"}

--- a/resources/META-INF/extensions/intentions.xml
+++ b/resources/META-INF/extensions/intentions.xml
@@ -26,6 +26,12 @@
 
         <intentionAction>
             <language>Latex</language>
+            <className>nl.hannahsten.texifyidea.intentions.LatexForwardSearchIntention</className>
+            <category>LaTeX</category>
+        </intentionAction>
+
+        <intentionAction>
+            <language>Latex</language>
             <className>nl.hannahsten.texifyidea.intentions.LatexInlineDisplayToggleIntention</className>
             <category>LaTeX</category>
         </intentionAction>

--- a/resources/intentionDescriptions/LatexForwardSearchIntention/description.html
+++ b/resources/intentionDescriptions/LatexForwardSearchIntention/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Jump from the current LaTeX source position to the corresponding location in the compiled PDF.
+</body>
+</html>

--- a/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
+++ b/src/nl/hannahsten/texifyidea/action/ForwardSearchAction.kt
@@ -19,15 +19,10 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
 
     override fun actionPerformed(file: VirtualFile, project: Project, textEditor: TextEditor) {
         if (file.fileType !is LatexFileType) return
-        val viewer = ForwardSearchSupport.resolveViewer(project, file, this.viewer) ?: return
-        if (!viewer.isAvailable() || !viewer.isForwardSearchSupported) return
 
-        val document = textEditor.editor.document
-        val line = document.getLineNumber(textEditor.editor.caretModel.offset) + 1
-        val outputPath = ForwardSearchSupport.resolveOutputPath(project, file)
         try {
-            viewer.forwardSearch(outputPath, file.path, line, project, focusAllowed = true)
-            this.viewer = viewer
+            val resolvedViewer = ForwardSearchSupport.performForwardSearch(project, file, textEditor.editor, fallbackViewer = viewer)
+            if (resolvedViewer != null) this.viewer = resolvedViewer
         }
         catch (e: TeXception) {
             // Show a notification if the forward search fails, but only catch TeXception and let other unexpected exceptions bubble up.
@@ -41,16 +36,11 @@ open class ForwardSearchAction(var viewer: PdfViewer? = null) : EditorAction(
     override fun update(e: AnActionEvent) {
         val project = e.project
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        val resolvedViewer = if (project != null && file != null) {
-            ForwardSearchSupport.resolveViewer(project, file, viewer)
-        }
-        else {
-            null
-        }
+
         e.presentation.isEnabledAndVisible =
+            project != null &&
             file?.fileType is LatexFileType &&
-            resolvedViewer?.isAvailable() == true &&
-            resolvedViewer.isForwardSearchSupported
+            ForwardSearchSupport.canForwardSearch(project, file, viewer)
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/src/nl/hannahsten/texifyidea/intentions/LatexForwardSearchIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexForwardSearchIntention.kt
@@ -20,6 +20,13 @@ class LatexForwardSearchIntention : TexifyIntentionBase("Forward search in PDF")
     override fun generatePreview(project: Project, editor: Editor, psiFile: PsiFile): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        // since isAvailable should be inexpensive, we only check the file type
+        // without looking for a supported viewer.
+//        return editor != null &&
+//                file != null &&
+//                file.fileType is LatexFileType &&
+//                file.virtualFile != null
+
         if (editor == null || file == null || file.fileType !is LatexFileType) return false
         val virtualFile = file.virtualFile ?: return false
 

--- a/src/nl/hannahsten/texifyidea/intentions/LatexForwardSearchIntention.kt
+++ b/src/nl/hannahsten/texifyidea/intentions/LatexForwardSearchIntention.kt
@@ -1,0 +1,50 @@
+package nl.hannahsten.texifyidea.intentions
+
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import nl.hannahsten.texifyidea.TeXception
+import nl.hannahsten.texifyidea.action.ForwardSearchAction
+import nl.hannahsten.texifyidea.file.LatexFileType
+import nl.hannahsten.texifyidea.run.pdfviewer.ForwardSearchSupport
+
+// A before and after template is expected for the intention.
+// However, forward search doesn't have a before/after preview.
+@Suppress("IntentionDescriptionNotFoundInspection")
+class LatexForwardSearchIntention : TexifyIntentionBase("Forward search in PDF") {
+
+    override fun generatePreview(project: Project, editor: Editor, psiFile: PsiFile): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        if (editor == null || file == null || file.fileType !is LatexFileType) return false
+        val virtualFile = file.virtualFile ?: return false
+
+        return ForwardSearchSupport.canForwardSearch(project, virtualFile, getForwardSearchAction()?.viewer)
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        if (editor == null || file == null || file.fileType !is LatexFileType) return
+        val virtualFile = file.virtualFile ?: return
+
+        val forwardAction = getForwardSearchAction()
+
+        try {
+            val resolvedViewer = ForwardSearchSupport.performForwardSearch(project, virtualFile, editor, fallbackViewer = forwardAction?.viewer)
+            if (resolvedViewer != null) forwardAction?.viewer = resolvedViewer
+        }
+        catch (e: TeXception) {
+            // Show a notification if the forward search fails, but only catch TeXception and let other unexpected exceptions bubble up.
+            Notification(
+                "LaTeX", "Forward search error", "${e.message}",
+                NotificationType.WARNING
+            ).notify(project)
+        }
+    }
+
+    private fun getForwardSearchAction() = ActionManager.getInstance()
+        .getAction("texify.ForwardSearch") as? ForwardSearchAction
+}

--- a/src/nl/hannahsten/texifyidea/run/pdfviewer/ForwardSearchSupport.kt
+++ b/src/nl/hannahsten/texifyidea/run/pdfviewer/ForwardSearchSupport.kt
@@ -1,6 +1,7 @@
 package nl.hannahsten.texifyidea.run.pdfviewer
 
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import nl.hannahsten.texifyidea.run.latex.LatexPathResolver
@@ -14,12 +15,44 @@ import nl.hannahsten.texifyidea.util.selectedRunConfig
 
 internal object ForwardSearchSupport {
 
-    fun resolveViewer(project: Project, sourceFile: VirtualFile, fallback: PdfViewer? = null): PdfViewer? = resolveRunConfig(project, sourceFile)?.pdfViewer
+    /**
+     * Checks if a viewer can be resolved and supports forward search.
+     */
+    fun canForwardSearch(project: Project, sourceFile: VirtualFile, fallback: PdfViewer? = null): Boolean {
+        val viewer = resolveViewer(project, sourceFile, fallback) ?: return false
+        return viewer.isAvailable() && viewer.isForwardSearchSupported
+    }
+
+    /**
+     * Resolves the viewer and performs a forward search based on the position in the
+     * given editor.
+     *
+     * @return the resolved viewer or `null` if no usable viewer got resolved
+     * @throws nl.hannahsten.texifyidea.TeXception if the viewer reports a forward search failure
+     */
+    fun performForwardSearch(
+        project: Project,
+        file: VirtualFile,
+        editor: Editor,
+        fallbackViewer: PdfViewer? = null,
+        focusAllowed: Boolean = true,
+    ): PdfViewer? {
+        val viewer = resolveViewer(project, file, fallbackViewer) ?: return null
+        if (!viewer.isAvailable() || !viewer.isForwardSearchSupported) return null
+
+        val document = editor.document
+        val line = document.getLineNumber(editor.caretModel.offset) + 1
+        val outputPath = resolveOutputPath(project, file)
+        viewer.forwardSearch(outputPath, file.path, line, project, focusAllowed)
+        return viewer
+    }
+
+    private fun resolveViewer(project: Project, sourceFile: VirtualFile, fallback: PdfViewer? = null): PdfViewer? = resolveRunConfig(project, sourceFile)?.pdfViewer
         ?: fallback
         ?: project.selectedRunConfig()?.pdfViewer
         ?: project.latexTemplateRunConfig()?.pdfViewer
 
-    fun resolveOutputPath(project: Project, sourceFile: VirtualFile): String? {
+    private fun resolveOutputPath(project: Project, sourceFile: VirtualFile): String? {
         val runConfig = resolveRunConfig(project, sourceFile) ?: return null
         val mainFile = LatexRunConfigurationStaticSupport.resolveMainFile(runConfig) ?: return null
         val outputDir = LatexPathResolver.resolveOutputDir(runConfig, mainFile) ?: return null

--- a/test/nl/hannahsten/texifyidea/action/ForwardSearchActionTest.kt
+++ b/test/nl/hannahsten/texifyidea/action/ForwardSearchActionTest.kt
@@ -1,18 +1,24 @@
 package nl.hannahsten.texifyidea.action
 
-import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
-import com.intellij.openapi.project.Project
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
-import nl.hannahsten.texifyidea.run.latex.LatexRunConfigurationProducer
-import nl.hannahsten.texifyidea.run.pdfviewer.NoViewer
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.testutils.RecordingForwardSearchViewer
+import nl.hannahsten.texifyidea.testutils.addLatexRunConfig
 import nl.hannahsten.texifyidea.updateFilesets
 import java.nio.file.Path
 
 class ForwardSearchActionTest : BasePlatformTestCase() {
+
+    override fun tearDown() {
+        try {
+            PdfViewer.additionalViewers = emptyList()
+        }
+        finally {
+            super.tearDown()
+        }
+    }
 
     fun testForwardSearchUsesRunConfigOfCurrentFileset() {
         myFixture.addFileToProject(
@@ -37,10 +43,12 @@ class ForwardSearchActionTest : BasePlatformTestCase() {
         myFixture.addFileToProject("b/chapter.tex", "B content")
         myFixture.updateFilesets()
 
-        addRunConfig("A", "a/root-a.tex", Path.of("{projectDir}", "out-a"))
-        addRunConfig("B", "b/root-b.tex", Path.of("{projectDir}", "out-b"))
+        project.addLatexRunConfig("A", "a/root-a.tex", Path.of("{projectDir}", "out-a"))
+        project.addLatexRunConfig("B", "b/root-b.tex", Path.of("{projectDir}", "out-b"))
 
         // Using a mockk object would give an exception: java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the schema
+        // This is probably because of intellij platform test instrumentation interfers with Mockk's one,
+        // and it only happens for mocked methods that return Unit (see https://github.com/mockk/mockk/issues/1422)
         val viewer = RecordingForwardSearchViewer()
         PdfViewer.additionalViewers = listOf(viewer)
 
@@ -56,39 +64,4 @@ class ForwardSearchActionTest : BasePlatformTestCase() {
         assertEquals(project, call.project)
         assertTrue(call.focusAllowed)
     }
-
-    private fun addRunConfig(name: String, mainFilePath: String, outputPath: Path): LatexRunConfiguration {
-        val factory = LatexRunConfigurationProducer().configurationFactory
-        val runConfig = LatexRunConfiguration(project, factory, name).apply {
-            this.mainFilePath = mainFilePath
-            this.outputPath = outputPath
-            pdfViewer = NoViewer
-        }
-        val settings = RunManagerImpl.getInstanceImpl(project).createConfiguration(runConfig, factory)
-        RunManagerImpl.getInstanceImpl(project).addConfiguration(settings)
-        return settings.configuration as LatexRunConfiguration
-    }
-
-    private class RecordingForwardSearchViewer : PdfViewer {
-
-        override val name: String = NoViewer.name
-        override val displayName: String = NoViewer.displayName
-        override val isForwardSearchSupported: Boolean = true
-
-        val forwardSearchCalls = mutableListOf<ForwardSearchCall>()
-
-        override fun isAvailable(): Boolean = true
-
-        override fun forwardSearch(outputPath: String?, sourceFilePath: String, line: Int, project: Project, focusAllowed: Boolean) {
-            forwardSearchCalls += ForwardSearchCall(outputPath, sourceFilePath, line, project, focusAllowed)
-        }
-    }
-
-    private data class ForwardSearchCall(
-        val outputPath: String?,
-        val sourceFilePath: String,
-        val line: Int,
-        val project: Project,
-        val focusAllowed: Boolean,
-    )
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/probablebugs/LatexUnicodeInspectionTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.testutils.resetUnicodeSupportMocks
 import nl.hannahsten.texifyidea.updateFilesets
 import nl.hannahsten.texifyidea.util.runCommandWithExitCode
 
@@ -181,6 +182,15 @@ class LatexUnicodeInspectionQuickFix : LatexUnicodeInspectionTest() {
 }
 
 abstract class LatexUnicodeInspectionTest : TexifyInspectionTestBase(LatexUnicodeInspection()) {
+
+    override fun tearDown() {
+        try {
+            resetUnicodeSupportMocks()
+        }
+        finally {
+            super.tearDown()
+        }
+    }
 
     fun setUnicodeSupport(enabled: Boolean = true) = nl.hannahsten.texifyidea.testutils.setUnicodeSupport(myFixture.project, enabled)
 }

--- a/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexRedundantEscapeInspectionTest.kt
+++ b/test/nl/hannahsten/texifyidea/inspections/latex/redundancy/LatexRedundantEscapeInspectionTest.kt
@@ -2,9 +2,19 @@ package nl.hannahsten.texifyidea.inspections.latex.redundancy
 
 import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.inspections.TexifyInspectionTestBase
+import nl.hannahsten.texifyidea.testutils.resetUnicodeSupportMocks
 import nl.hannahsten.texifyidea.testutils.setUnicodeSupport
 
 class LatexRedundantEscapeInspectionTest : TexifyInspectionTestBase(LatexRedundantEscapeInspection()) {
+
+    override fun tearDown() {
+        try {
+            resetUnicodeSupportMocks()
+        }
+        finally {
+            super.tearDown()
+        }
+    }
 
     fun `test no warning when no unicode support`() {
         setUnicodeSupport(myFixture.project, false)

--- a/test/nl/hannahsten/texifyidea/intentions/LatexForwardSearchIntentionTest.kt
+++ b/test/nl/hannahsten/texifyidea/intentions/LatexForwardSearchIntentionTest.kt
@@ -1,0 +1,67 @@
+package nl.hannahsten.texifyidea.intentions
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import nl.hannahsten.texifyidea.action.ForwardSearchAction
+import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+import nl.hannahsten.texifyidea.testutils.RecordingForwardSearchViewer
+import nl.hannahsten.texifyidea.testutils.addLatexRunConfig
+import nl.hannahsten.texifyidea.updateFilesets
+import java.nio.file.Path
+
+class LatexForwardSearchIntentionTest : BasePlatformTestCase() {
+
+    override fun tearDown() {
+        try {
+            (ActionManager.getInstance().getAction("texify.ForwardSearch") as? ForwardSearchAction)?.viewer = null
+            PdfViewer.additionalViewers = emptyList()
+        }
+        finally {
+            super.tearDown()
+        }
+    }
+
+    fun testForwardSearchUsesRunConfigOfCurrentFileset() {
+        myFixture.addFileToProject(
+            "a/root-a.tex",
+            """
+            \documentclass{article}
+            \begin{document}
+            \input{chapter}
+            \end{document}
+            """.trimIndent()
+        )
+        val aChapter = myFixture.addFileToProject("a/chapter.tex", "A content")
+        myFixture.addFileToProject(
+            "b/root-b.tex",
+            """
+            \documentclass{article}
+            \begin{document}
+            \input{chapter}
+            \end{document}
+            """.trimIndent()
+        )
+        myFixture.addFileToProject("b/chapter.tex", "B content")
+        myFixture.updateFilesets()
+
+        project.addLatexRunConfig("A", "a/root-a.tex", Path.of("{projectDir}", "out-a"))
+        project.addLatexRunConfig("B", "b/root-b.tex", Path.of("{projectDir}", "out-b"))
+
+        // Using a mockk object would give an exception: java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the schema
+        // This is probably because of intellij platform test instrumentation interfers with Mockk's one,
+        // and it only happens for mocked methods that return Unit (see https://github.com/mockk/mockk/issues/1422)
+        val viewer = RecordingForwardSearchViewer()
+        PdfViewer.additionalViewers = listOf(viewer)
+
+        myFixture.openFileInEditor(aChapter.virtualFile)
+
+        LatexForwardSearchIntention().invoke(project, myFixture.editor, aChapter)
+
+        assertEquals(1, viewer.forwardSearchCalls.size)
+        val call = viewer.forwardSearchCalls.single()
+        assertTrue(call.outputPath?.endsWith("/a/root-a.pdf") == true)
+        assertEquals(aChapter.virtualFile.path, call.sourceFilePath)
+        assertEquals(project, call.project)
+        assertTrue(call.focusAllowed)
+    }
+}

--- a/test/nl/hannahsten/texifyidea/testutils/Common.kt
+++ b/test/nl/hannahsten/texifyidea/testutils/Common.kt
@@ -1,5 +1,6 @@
 package nl.hannahsten.texifyidea.testutils
 
+import com.intellij.execution.impl.RunManagerImpl
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture
@@ -11,12 +12,15 @@ import io.mockk.mockkStatic
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
 import nl.hannahsten.texifyidea.run.latex.LatexCompileStepOptions
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
+import nl.hannahsten.texifyidea.run.latex.LatexRunConfigurationProducer
+import nl.hannahsten.texifyidea.run.pdfviewer.NoViewer
 import nl.hannahsten.texifyidea.settings.conventions.TexifyConventionsSettings
 import nl.hannahsten.texifyidea.settings.conventions.TexifyConventionsSettingsManager
 import nl.hannahsten.texifyidea.settings.sdk.MiktexWindowsSdk
 import nl.hannahsten.texifyidea.settings.sdk.TexliveSdk
 import nl.hannahsten.texifyidea.util.selectedRunConfig
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+import java.nio.file.Path
 
 /**
  * Execute the given action as write command.
@@ -66,3 +70,27 @@ fun setUnicodeSupport(project: Project, enabled: Boolean = true) {
 }
 
 fun String.toSystemNewLine() = replace(Regex("\n|\r\n"), System.lineSeparator())
+
+/**
+ * Adds a new LaTeX run configuration to the project.
+ *
+ * @param name The name of the run configuration.
+ * @param mainFilePath The path to the main LaTeX file to be compiled.
+ * @param outputPath The directory path where the outputs (e.g., PDF files) will be generated.
+ * @return The created instance of [LatexRunConfiguration].
+ */
+fun Project.addLatexRunConfig(
+    name: String,
+    mainFilePath: String,
+    outputPath: Path,
+): LatexRunConfiguration {
+    val factory = LatexRunConfigurationProducer().configurationFactory
+    val runConfig = LatexRunConfiguration(this, factory, name).apply {
+        this.mainFilePath = mainFilePath
+        this.outputPath = outputPath
+        pdfViewer = NoViewer
+    }
+    val settings = RunManagerImpl.getInstanceImpl(this).createConfiguration(runConfig, factory)
+    RunManagerImpl.getInstanceImpl(this).addConfiguration(settings)
+    return settings.configuration as LatexRunConfiguration
+}

--- a/test/nl/hannahsten/texifyidea/testutils/Common.kt
+++ b/test/nl/hannahsten/texifyidea/testutils/Common.kt
@@ -9,6 +9,9 @@ import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import nl.hannahsten.texifyidea.run.compiler.LatexCompiler
 import nl.hannahsten.texifyidea.run.latex.LatexCompileStepOptions
 import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
@@ -48,11 +51,18 @@ fun IdeaProjectTestFixture.updateConvention(action: (settings: TexifyConventions
 /**
  * Set the selected compiler in the selected run configuration and the Latex Distribution in a way to ensure either unicode
  * support, or no unicode support.
+ *
+ * Tests that use this function must call `resetUnicodeSupportMocks()` during tearDown.
  */
 fun setUnicodeSupport(project: Project, enabled: Boolean = true) {
     mockkStatic("nl.hannahsten.texifyidea.util.ProjectsKt")
     val runConfig = mockk<LatexRunConfiguration>()
     every { project.selectedRunConfig() } returns runConfig
+
+    // getters that are implicitly called by the LatexForwardSearchIntention#isAvailable
+    every { runConfig.mainFilePath } returns null
+    every { runConfig.pdfViewer } returns null
+
     if (enabled) {
         // Unicode is always supported in lualatex.
         every { runConfig.primaryCompileStep() } returns LatexCompileStepOptions().apply { compiler = LatexCompiler.LUALATEX }
@@ -67,6 +77,17 @@ fun setUnicodeSupport(project: Project, enabled: Boolean = true) {
         mockkConstructor(MiktexWindowsSdk::class)
         every { anyConstructed<MiktexWindowsSdk>().getVersion(null) } returns DefaultArtifactVersion("2.9.7300")
     }
+}
+
+/**
+ * Resets mocks that were set during `setUnicodeSupport()`.
+ *
+ * It should be called by all test classes that use `setUnicodeSupport()`.
+ */
+fun resetUnicodeSupportMocks() {
+    runCatching { unmockkStatic("nl.hannahsten.texifyidea.util.ProjectsKt") }
+    runCatching { unmockkObject(TexliveSdk.Cache) }
+    runCatching { unmockkConstructor(MiktexWindowsSdk::class) }
 }
 
 fun String.toSystemNewLine() = replace(Regex("\n|\r\n"), System.lineSeparator())

--- a/test/nl/hannahsten/texifyidea/testutils/RecordingForwardSearchViewer.kt
+++ b/test/nl/hannahsten/texifyidea/testutils/RecordingForwardSearchViewer.kt
@@ -1,0 +1,28 @@
+package nl.hannahsten.texifyidea.testutils
+
+import com.intellij.openapi.project.Project
+import nl.hannahsten.texifyidea.run.pdfviewer.NoViewer
+import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
+
+class RecordingForwardSearchViewer : PdfViewer {
+
+    override val name: String = NoViewer.name
+    override val displayName: String = NoViewer.displayName
+    override val isForwardSearchSupported: Boolean = true
+
+    val forwardSearchCalls = mutableListOf<ForwardSearchCall>()
+
+    override fun isAvailable(): Boolean = true
+
+    override fun forwardSearch(outputPath: String?, sourceFilePath: String, line: Int, project: Project, focusAllowed: Boolean) {
+        forwardSearchCalls += ForwardSearchCall(outputPath, sourceFilePath, line, project, focusAllowed)
+    }
+
+    data class ForwardSearchCall(
+        val outputPath: String?,
+        val sourceFilePath: String,
+        val line: Int,
+        val project: Project,
+        val focusAllowed: Boolean,
+    )
+}


### PR DESCRIPTION
<!-- The issue that is fixed by this PR, if applicable: -->
Fix #4442 

#### Summary of additions and changes

* Adds `LatexForwardSearchIntention`, allowing users to jump from the caret position in a LaTeX file to the corresponding location in the PDF via `Alt+Enter` → `Forward Search in PDF`.
* Extracts the core forward search logic into the `ForwardSearchSupport` object class to allow sharing between the `ForwardSearchAction` and the new intention.
* Extracts some helper constructs for ForwardSearch testing into the testutils
* Adds a `LatexForwardSearchIntentionTest`
* Adds mock cleanup during tearDown of `LatexRedundantEscapeInspectionTest` and `LatexUnicodeInspectionTest` which were interfering with subsequent tests

#### Screenshot
<img width="974" height="532" alt="Screenshot 2026-06-26 at 11 29 15" src="https://github.com/user-attachments/assets/19a19435-2e4b-4d0d-859c-887ae30b1a03" />
