### PR TITLE
Fix forward search editor context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+* Fixed forward search resetting to page 1 on second compilation
 * Fixed command highlighting in \textbf, \textit, etc.
 * Fixed issues where some table environments were not recognised as such
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion = 1.0.1-alpha.7
+pluginVersion = 1.0.1-alpha.8
 
 #     Info about build ranges: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
 #    Note that an xyz branch corresponds to version 20xy.z and a since build of xyz.*

--- a/src/nl/hannahsten/texifyidea/run/latex/LatexRunSessionState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/LatexRunSessionState.kt
@@ -7,6 +7,16 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPsiElementPointer
 import java.nio.file.Path
 
+data class TextEditorSnapshot(
+    val sourceFilePath: String,
+    val line: Int,
+)
+
+data class TextEditorContextSnapshot(
+    val focused: TextEditorSnapshot?,
+    val selected: TextEditorSnapshot?,
+)
+
 data class LatexRunSessionState(
     val project: Project,
     val mainFile: VirtualFile,
@@ -17,6 +27,7 @@ data class LatexRunSessionState(
     val latexSdk: Sdk?,
     val auxDir: VirtualFile? = null,
     val psiFile: SmartPsiElementPointer<PsiFile>? = null,
+    var editorContext: TextEditorContextSnapshot? = null,
     /** Absolute path to the compiled document output file (for example the generated PDF/XDV). */
     var resolvedOutputFilePath: String? = null,
     val filesToCleanUp: MutableList<Path> = mutableListOf(),

--- a/src/nl/hannahsten/texifyidea/run/latex/flow/LatexStepRunState.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/flow/LatexStepRunState.kt
@@ -6,15 +6,18 @@ import com.intellij.execution.ExecutionResult
 import com.intellij.execution.Executor
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.Project
 import nl.hannahsten.texifyidea.editor.autocompile.AutoCompileDoneListener
-import nl.hannahsten.texifyidea.run.latex.LatexSessionInitializer
-import nl.hannahsten.texifyidea.run.latex.LatexRunConfiguration
-import nl.hannahsten.texifyidea.run.latex.LatexStepRunConfigurationOptions
-import nl.hannahsten.texifyidea.run.latex.step.LatexRunStepPlanBuilder
+import nl.hannahsten.texifyidea.run.latex.*
 import nl.hannahsten.texifyidea.run.latex.step.LatexRunStepContext
+import nl.hannahsten.texifyidea.run.latex.step.LatexRunStepPlanBuilder
 import nl.hannahsten.texifyidea.run.latex.steplog.LatexStepLogTabComponent
 import nl.hannahsten.texifyidea.util.Log
+import nl.hannahsten.texifyidea.util.focusedTextEditor
+import nl.hannahsten.texifyidea.util.selectedTextEditor
 
 /**
  * Run-profile state that executes the step-based LaTeX pipeline.
@@ -30,6 +33,8 @@ internal class LatexStepRunState(
     override fun execute(executor: Executor?, runner: ProgramRunner<*>): ExecutionResult {
         FileDocumentManager.getInstance().saveAllDocuments()
         val session = LatexSessionInitializer.initialize(runConfig, environment)
+        // We need to capture the focused editor before execution, otherwise focus will change to the run tool window
+        session.editorContext = captureEditorContext(environment.project)
 
         val configuredPlan = LatexRunStepPlanBuilder.build(configuredSteps)
         if (configuredPlan.unsupportedTypes.isNotEmpty()) {
@@ -48,5 +53,36 @@ internal class LatexStepRunState(
         val stepLogConsole = LatexStepLogTabComponent(environment.project, session.mainFile, overallHandler)
 
         return DefaultExecutionResult(stepLogConsole, overallHandler)
+    }
+
+    private fun captureEditorContext(project: Project): TextEditorContextSnapshot? {
+        val app = ApplicationManager.getApplication()
+        val context = if (app.isDispatchThread) {
+            readEditorContext(project)
+        }
+        else {
+            var captured: TextEditorContextSnapshot? = null
+            app.invokeAndWait {
+                captured = readEditorContext(project)
+            }
+            captured
+        }
+        return context?.takeIf { it.focused != null || it.selected != null }
+    }
+
+    private fun readEditorContext(project: Project): TextEditorContextSnapshot =
+        TextEditorContextSnapshot(
+            focused = snapshot(project.focusedTextEditor()),
+            selected = snapshot(project.selectedTextEditor()),
+        )
+
+    private fun snapshot(editor: TextEditor?): TextEditorSnapshot? {
+        val textEditor = editor ?: return null
+        val sourceFile = FileDocumentManager.getInstance().getFile(textEditor.editor.document) ?: return null
+        val line = textEditor.editor.document.getLineNumber(textEditor.editor.caretModel.offset) + 1
+        return TextEditorSnapshot(
+            sourceFilePath = sourceFile.path,
+            line = line,
+        )
     }
 }

--- a/src/nl/hannahsten/texifyidea/run/latex/step/PdfViewerRunStep.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/step/PdfViewerRunStep.kt
@@ -114,7 +114,8 @@ internal class PdfViewerRunStep(
             ?: project.selectedTextEditor()?.editor
             // Fallback in case both a tex file and the pdf file are selected (in different windows)
             ?: project.selectedTextEditors().firstOrNull { it.editor.virtualFile?.fileType == LatexFileType }?.editor
-        val editorFile = editor?.document?.let { FileDocumentManager.getInstance().getFile(it) } ?: return null
+            ?: return null
+        val editorFile = editor.document.let { FileDocumentManager.getInstance().getFile(it) } ?: return null
         val line = editor.document.getLineNumber(editor.caretOffset()) + 1
         return SourceContext(editorFile, line)
     }

--- a/src/nl/hannahsten/texifyidea/run/latex/step/PdfViewerRunStep.kt
+++ b/src/nl/hannahsten/texifyidea/run/latex/step/PdfViewerRunStep.kt
@@ -4,16 +4,21 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.execution.ParametersListUtil
 import nl.hannahsten.texifyidea.TeXception
 import nl.hannahsten.texifyidea.action.ForwardSearchAction
+import nl.hannahsten.texifyidea.file.LatexFileType
 import nl.hannahsten.texifyidea.run.common.createCompilationHandler
 import nl.hannahsten.texifyidea.run.latex.PdfViewerStepOptions
+import nl.hannahsten.texifyidea.run.latex.TextEditorSnapshot
 import nl.hannahsten.texifyidea.run.pdfviewer.ForwardSearchSupport
 import nl.hannahsten.texifyidea.run.pdfviewer.PdfViewer
 import nl.hannahsten.texifyidea.util.caretOffset
 import nl.hannahsten.texifyidea.util.focusedTextEditor
 import nl.hannahsten.texifyidea.util.selectedTextEditor
+import nl.hannahsten.texifyidea.util.selectedTextEditors
 
 internal class PdfViewerRunStep(
     private val stepConfig: PdfViewerStepOptions,
@@ -76,35 +81,50 @@ internal class PdfViewerRunStep(
         val viewer = PdfViewer.availableViewers
             .firstOrNull { it.name == stepConfig.pdfViewerName }
             ?: PdfViewer.firstAvailableViewer
-        val editor = context.environment.project.focusedTextEditor()?.editor
-            ?: context.environment.project.selectedTextEditor()?.editor
-        val editorFile = editor?.document?.let { FileDocumentManager.getInstance().getFile(it) }
-        val useEditorSource = editorFile?.let {
+        val project = context.environment.project
+        val source = resolveSourceContext(context)
+            ?: return null
+        val useResolvedSource =
             ForwardSearchSupport.sourceBelongsToMainFileset(
-                project = context.environment.project,
-                sourceFile = it,
+                project = project,
+                sourceFile = source.file,
                 mainFile = context.session.mainFile,
             )
-        } == true
-        val line = if (useEditorSource) {
-            editor.document.getLineNumber(editor.caretOffset()) + 1
-        }
-        else {
-            0
-        }
-        val sourceFilePath = if (useEditorSource) {
-            editorFile.path
-        }
-        else {
-            context.session.mainFile.path
-        }
+
+        // No forward search if we are not in the fileset, to avoid resetting the pdf view
+        if (!useResolvedSource) return null
 
         return ResolvedViewerContext(
             viewer = viewer,
             outputFilePath = outputFilePath,
-            sourceFilePath = sourceFilePath,
-            line = line,
+            sourceFilePath = source.file.path,
+            line = source.line,
         )
+    }
+
+    /**
+     * Use the information from before starting execution to determine what editor was focused, or fall back to currently open editors.
+     */
+    private fun resolveSourceContext(context: LatexRunStepContext): SourceContext? {
+        val snapshot = context.session.editorContext?.focused ?: context.session.editorContext?.selected
+        snapshot?.toSourceContext()?.let { return it }
+
+        val project = context.environment.project
+        val editor = project.focusedTextEditor()?.editor
+            ?: project.selectedTextEditor()?.editor
+            // Fallback in case both a tex file and the pdf file are selected (in different windows)
+            ?: project.selectedTextEditors().firstOrNull { it.editor.virtualFile?.fileType == LatexFileType }?.editor
+        val editorFile = editor?.document?.let { FileDocumentManager.getInstance().getFile(it) } ?: return null
+        val line = editor.document.getLineNumber(editor.caretOffset()) + 1
+        return SourceContext(editorFile, line)
+    }
+
+    private fun TextEditorSnapshot.toSourceContext(): SourceContext? {
+        if (line <= 0) {
+            return null
+        }
+        val file = LocalFileSystem.getInstance().findFileByPath(sourceFilePath) ?: return null
+        return SourceContext(file, line)
     }
 
     private fun openStandardViewer(
@@ -150,6 +170,11 @@ internal class PdfViewerRunStep(
         val viewer: PdfViewer,
         val outputFilePath: String,
         val sourceFilePath: String,
+        val line: Int,
+    )
+
+    private data class SourceContext(
+        val file: VirtualFile,
         val line: Int,
     )
 }

--- a/src/nl/hannahsten/texifyidea/util/Projects.kt
+++ b/src/nl/hannahsten/texifyidea/util/Projects.kt
@@ -129,6 +129,8 @@ fun Project.focusedTextEditor(): TextEditor? = FileEditorManager.getInstance(thi
  */
 fun Project.selectedTextEditor(): TextEditor? = FileEditorManager.getInstance(this).selectedEditor as? TextEditor?
 
+fun Project.selectedTextEditors(): List<TextEditor> = FileEditorManager.getInstance(this).selectedEditors.filterIsInstance<TextEditor>()
+
 fun Project.selectedTextEditorOrWarning(): TextEditor? {
     selectedTextEditor()?.let { return it }
     Notification("LaTeX", "Could not find an open editor to insert text", "Put your caret in a LaTeX file first. Please report an issue on GitHub if you believe this is incorrect", NotificationType.ERROR).notify(this)

--- a/test/nl/hannahsten/texifyidea/run/latex/step/PdfViewerRunStepTest.kt
+++ b/test/nl/hannahsten/texifyidea/run/latex/step/PdfViewerRunStepTest.kt
@@ -282,12 +282,8 @@ class PdfViewerRunStepTest : BasePlatformTestCase() {
 
         step.beforeStart(context)
 
-        assertEquals(1, viewer.forwardSearchCalls.size)
-        val call = viewer.forwardSearchCalls.single()
-        assertEquals(context.session.resolvedOutputFilePath, call.outputPath)
-        assertEquals(main.path, call.sourceFilePath)
-        assertEquals(0, call.line)
-        assertEquals(project, call.project)
+        // It doesn't make sense to forward search if the caret is in an unrelated file, since the user probably wants to keep looking at the same page
+        assertEquals(0, viewer.forwardSearchCalls.size)
     }
 
     private fun mockNoViewer(openFileError: Throwable? = null): RecordingPdfViewer = RecordingPdfViewer(openFileError).also {
@@ -362,6 +358,7 @@ class PdfViewerRunStepTest : BasePlatformTestCase() {
             latexSdk = null,
             auxDir = outputDir,
             resolvedOutputFilePath = outputFilePath?.let(outputDirPath::resolve)?.toString(),
+            editorContext = TextEditorContextSnapshot(focused = TextEditorSnapshot(mainFilePath.toString(), 1), selected = null)
         )
         return LatexRunStepContext(runConfig, environment, state)
     }


### PR DESCRIPTION
On second compilation, it would go to line 0 because it lost the focus and selectedEditor would be on the pdf from the previous compile.